### PR TITLE
Releases v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-01-25
+
 ### Added
 - `/release` skill for automated version releases (#30)
 - GitHub Actions CI workflow with multi-version testing matrix (#15)
@@ -83,5 +85,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration tests for encrypt/decrypt round-trips
 - AES KeyWrap test support module
 
-[Unreleased]: https://github.com/riddler/aws-encryption-sdk-elixir/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/riddler/aws-encryption-sdk-elixir/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/riddler/aws-encryption-sdk-elixir/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/riddler/aws-encryption-sdk-elixir/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,8 +251,8 @@ mix hex.publish
 - [x] Basic encryption/decryption (non-streaming)
 
 ### Milestone 2: Keyrings
-- [ ] Keyring behaviour
-- [ ] Raw AES Keyring
+- [x] Keyring behaviour
+- [x] Raw AES Keyring
 - [ ] Raw RSA Keyring
 - [ ] Multi-Keyring
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ An Elixir implementation of the [AWS Encryption SDK](https://docs.aws.amazon.com
 
 ## Current Status
 
-**Version**: 0.1.0 (pre-release)
+**Version**: 0.2.0 (pre-release)
 
 ### Implemented Features
 
@@ -24,18 +24,20 @@ An Elixir implementation of the [AWS Encryption SDK](https://docs.aws.amazon.com
 - ✅ Framed and non-framed body formats
 - ✅ Key commitment verification for committed algorithm suites
 - ✅ Test vector harness for cross-SDK compatibility testing
+- ✅ Keyring behaviour interface
+- ✅ Raw AES keyring
 
 ### Not Yet Implemented
 
-- ❌ Keyrings (Raw AES, Raw RSA, AWS KMS)
+- ❌ Keyrings (Raw RSA, AWS KMS)
 - ❌ Cryptographic Materials Manager (CMM)
 - ❌ Streaming encryption/decryption
 - ❌ ECDSA signing for signed algorithm suites
 
 ### Test Coverage
 
-- 181 tests passing
-- 90.6% code coverage
+- 230 tests passing
+- 91.1% code coverage
 
 ## Installation
 
@@ -44,7 +46,7 @@ Add `aws_encryption_sdk` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:aws_encryption_sdk, "~> 0.1.0"}
+    {:aws_encryption_sdk, "~> 0.2.0"}
   ]
 end
 ```
@@ -99,7 +101,7 @@ See [CHANGELOG.md](CHANGELOG.md) for detailed change history.
 
 **Planned for future releases:**
 
-1. **Keyrings** - Raw AES, Raw RSA, and AWS KMS keyrings
+1. **Keyrings** - Raw RSA and AWS KMS keyrings
 2. **CMM** - Cryptographic Materials Manager with caching
 3. **Streaming** - Large file encryption/decryption
 4. **Signatures** - ECDSA signing for signed algorithm suites

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule AwsEncryptionSdk.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.2.0"
   @source_url "https://github.com/riddler/aws-encryption-sdk-elixir"
 
   def project do


### PR DESCRIPTION
### Added
- `/release` skill for automated version releases (#30)
- GitHub Actions CI workflow with multi-version testing matrix (#15)
- Test matrix for Elixir 1.16-1.18 and OTP 26-27
- Codecov integration for coverage reporting
- CI and coverage status badges in README
- `:crypto` application to extra_applications for proper OTP loading
- Keyring behaviour interface with on_encrypt/on_decrypt callbacks (#25)
- Helper functions for data key generation and provider ID validation
- Support for optional plaintext_data_key in materials structs
- DecryptionMaterials.new_for_decrypt/3 and set_plaintext_data_key/2
- EncryptionMaterials.new_for_encrypt/3, set_plaintext_data_key/2, and add_encrypted_data_key/2
- Comprehensive test coverage for keyring behaviour (20 new tests)
- Raw AES keyring implementation with AES-128/192/256 support (#26)
- Provider info serialization for keyring metadata (key name, IV, tag length)
- wrap_key/2 function for encrypting data keys with AES-GCM
- unwrap_key/3 function for decrypting EDKs with provider ID and key name matching
- Comprehensive unit tests (25 tests) and test vector validation (4 vectors)
- Edge case tests for empty/large contexts, unicode, and all key sizes

### Changed
- Minimum Elixir version requirement from 1.18 to 1.16
- Minimum OTP version requirement to 26