### PR TITLE
Releases v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-01-27
+
 ### Added
 - CMM (Cryptographic Materials Manager) behaviour interface (#36)
 - get_encryption_materials/2 and get_decryption_materials/2 callbacks
@@ -159,7 +161,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration tests for encrypt/decrypt round-trips
 - AES KeyWrap test support module
 
-[Unreleased]: https://github.com/riddler/aws-encryption-sdk-elixir/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/riddler/aws-encryption-sdk-elixir/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/riddler/aws-encryption-sdk-elixir/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/riddler/aws-encryption-sdk-elixir/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/riddler/aws-encryption-sdk-elixir/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/riddler/aws-encryption-sdk-elixir/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,10 +257,10 @@ mix hex.publish
 - [x] Multi-Keyring
 
 ### Milestone 3: CMM & Full API
-- [ ] CMM behaviour
-- [ ] Default CMM
-- [ ] Encrypt API with commitment policy
-- [ ] Decrypt API with commitment policy
+- [x] CMM behaviour
+- [x] Default CMM
+- [x] Encrypt API with commitment policy
+- [x] Decrypt API with commitment policy
 
 ### Milestone 4: AWS Integration
 - [ ] AWS KMS Keyring

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ An Elixir implementation of the [AWS Encryption SDK](https://docs.aws.amazon.com
 
 ## Current Status
 
-**Version**: 0.3.0 (pre-release)
+**Version**: 0.4.0 (pre-release)
 
 ### Implemented Features
 
@@ -28,18 +28,20 @@ An Elixir implementation of the [AWS Encryption SDK](https://docs.aws.amazon.com
 - ✅ Raw AES keyring
 - ✅ Raw RSA keyring (all 5 padding schemes)
 - ✅ Multi-keyring composition
+- ✅ Cryptographic Materials Manager (CMM) with Default implementation
+- ✅ Client module with commitment policy enforcement
+- ✅ ECDSA signing for signed algorithm suites (P-384)
+- ✅ Support for all 17 algorithm suites
 
 ### Not Yet Implemented
 
 - ❌ AWS KMS keyring
-- ❌ Cryptographic Materials Manager (CMM)
 - ❌ Streaming encryption/decryption
-- ❌ ECDSA signing for signed algorithm suites
 
 ### Test Coverage
 
-- 312 tests passing
-- 92.1% code coverage
+- 469 tests passing
+- 93.8% code coverage
 
 ## Installation
 
@@ -48,7 +50,7 @@ Add `aws_encryption_sdk` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:aws_encryption_sdk, "~> 0.3.0"}
+    {:aws_encryption_sdk, "~> 0.4.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule AwsEncryptionSdk.MixProject do
   use Mix.Project
 
-  @version "0.3.0"
+  @version "0.4.0"
   @source_url "https://github.com/riddler/aws-encryption-sdk-elixir"
 
   def project do


### PR DESCRIPTION
### Added
- CMM (Cryptographic Materials Manager) behaviour interface (#36)
- get_encryption_materials/2 and get_decryption_materials/2 callbacks
- Commitment policy type definitions (forbid/require encrypt/decrypt)
- Helper functions for commitment policy validation
- Helper functions for materials validation (encryption and decryption)
- Helper functions for encryption context validation
- Reserved key constant for signature verification (aws-crypto-public-key)
- Default algorithm suite selection based on commitment policy
- Reproduced encryption context validation and merging
- Comprehensive test suite (54 tests, 100% coverage)
- Default CMM implementation with keyring orchestration (#37)
- ECDSA crypto module for P-384 key pair generation
- Support for all 17 algorithm suites (signing and non-signing)
- Algorithm suite selection based on commitment policy
- Signing key generation for ECDSA algorithm suites
- Public key encoding/storage in encryption context
- Verification key extraction from encryption context
- Reproduced encryption context validation and merging
- Comprehensive test suite (25 unit tests, 4 error handling tests)
- Round-trip encryption/decryption tests with signing suites
- Multi-keyring integration tests
- Test vector support framework (harness setup)
- Client module with commitment policy enforcement (#38)
- encrypt/3 and encrypt_with_keyring/3 APIs with policy validation
- Support for three commitment policies per spec (forbid/require/allow)
- Default policy of :require_encrypt_require_decrypt (strictest)
- max_encrypted_data_keys configuration option
- ECDSA sign/verify functions for signature operations
- Round-trip encryption/decryption tests for signed suites
- Client commitment policy test suite (47 tests, 100% coverage)
- Client test vector validation (3 encrypt test cases)
- Client.decrypt/3 with commitment policy enforcement for decryption (#39)
- Client.decrypt_with_keyring/3 convenience function for keyring-based decryption
- AwsEncryptionSdk.decrypt/2-3 public API accepting Client or DecryptionMaterials
- AwsEncryptionSdk.decrypt_with_keyring/3 public API delegation
- Commitment policy validation during decryption (strictest policy rejects non-committed suites)
- EDK count limit enforcement during decryption (max_encrypted_data_keys)
- Comprehensive integration test suite with 9 tests covering all three commitment policies
- 16 new tests for Client-based and public API decryption (469 total tests, 93.8% coverage)

### Changed
- Increased minimum code coverage requirement from 92% to 93%
- Added edge case tests for encryption context and encrypted data keys
- Main API now recommends Client-based encryption workflow
- Renamed encrypt/decrypt to encrypt_with_materials/decrypt_with_materials
- Removed encryption context validation from Encrypt module
- Updated documentation with Client usage examples