### PR TITLE
Implements AWS KMS MRK Discovery Keyring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- AWS KMS MRK Discovery Keyring for cross-region MRK decryption (#51)
+- MRK-aware discovery keyring reconstructing ARNs with configured region
+- Cross-region MRK decryption enabling disaster recovery scenarios
+- Non-MRK key filtering by region match for security
+- Optional discovery filter for partition and account restrictions
+- Integration with Default CMM and Multi-keyring dispatch clauses
+- Comprehensive test suite with 28 tests
 - KMS client abstraction layer with behaviour interface (#46)
 - KmsClient behaviour defining generate_data_key/5, encrypt/5, and decrypt/5 callbacks
 - Mock KMS client implementation for testing without AWS credentials

--- a/lib/aws_encryption_sdk/cmm/default.ex
+++ b/lib/aws_encryption_sdk/cmm/default.ex
@@ -34,7 +34,17 @@ defmodule AwsEncryptionSdk.Cmm.Default do
   alias AwsEncryptionSdk.AlgorithmSuite
   alias AwsEncryptionSdk.Cmm.Behaviour, as: CmmBehaviour
   alias AwsEncryptionSdk.Crypto.ECDSA
-  alias AwsEncryptionSdk.Keyring.{AwsKms, AwsKmsDiscovery, AwsKmsMrk, Multi, RawAes, RawRsa}
+
+  alias AwsEncryptionSdk.Keyring.{
+    AwsKms,
+    AwsKmsDiscovery,
+    AwsKmsMrk,
+    AwsKmsMrkDiscovery,
+    Multi,
+    RawAes,
+    RawRsa
+  }
+
   alias AwsEncryptionSdk.Materials.{DecryptionMaterials, EncryptedDataKey, EncryptionMaterials}
 
   @type keyring ::
@@ -44,6 +54,7 @@ defmodule AwsEncryptionSdk.Cmm.Default do
           | AwsKms.t()
           | AwsKmsDiscovery.t()
           | AwsKmsMrk.t()
+          | AwsKmsMrkDiscovery.t()
 
   @type t :: %__MODULE__{
           keyring: keyring()
@@ -101,6 +112,10 @@ defmodule AwsEncryptionSdk.Cmm.Default do
     AwsKmsMrk.wrap_key(keyring, materials)
   end
 
+  def call_wrap_key(%AwsKmsMrkDiscovery{} = keyring, materials) do
+    AwsKmsMrkDiscovery.wrap_key(keyring, materials)
+  end
+
   def call_wrap_key(keyring, _materials) do
     {:error, {:unsupported_keyring_type, keyring.__struct__}}
   end
@@ -130,6 +145,10 @@ defmodule AwsEncryptionSdk.Cmm.Default do
 
   def call_unwrap_key(%AwsKmsMrk{} = keyring, materials, edks) do
     AwsKmsMrk.unwrap_key(keyring, materials, edks)
+  end
+
+  def call_unwrap_key(%AwsKmsMrkDiscovery{} = keyring, materials, edks) do
+    AwsKmsMrkDiscovery.unwrap_key(keyring, materials, edks)
   end
 
   def call_unwrap_key(keyring, _materials, _edks) do

--- a/lib/aws_encryption_sdk/keyring/aws_kms_mrk_discovery.ex
+++ b/lib/aws_encryption_sdk/keyring/aws_kms_mrk_discovery.ex
@@ -1,0 +1,281 @@
+defmodule AwsEncryptionSdk.Keyring.AwsKmsMrkDiscovery do
+  @moduledoc """
+  AWS KMS MRK Discovery Keyring implementation.
+
+  A decrypt-only keyring that combines discovery keyring behavior with MRK awareness.
+  For MRK keys, it reconstructs the ARN with the configured region, enabling
+  cross-region decryption. For non-MRK keys, it filters out EDKs where the
+  region doesn't match.
+
+  ## Example
+
+      {:ok, client} = KmsClient.ExAws.new(region: "us-west-2")
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(client, "us-west-2")
+
+      # Can decrypt MRK-encrypted data from ANY region
+      {:ok, materials} = AwsKmsMrkDiscovery.unwrap_key(keyring, materials, edks)
+
+  ## Spec Reference
+
+  https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/framework/aws-kms/aws-kms-mrk-discovery-keyring.md
+  """
+
+  @behaviour AwsEncryptionSdk.Keyring.Behaviour
+
+  alias AwsEncryptionSdk.Keyring.Behaviour, as: KeyringBehaviour
+  alias AwsEncryptionSdk.Keyring.KmsKeyArn
+  alias AwsEncryptionSdk.Materials.{DecryptionMaterials, EncryptedDataKey, EncryptionMaterials}
+
+  @type discovery_filter :: %{
+          partition: String.t(),
+          accounts: [String.t(), ...]
+        }
+
+  @type t :: %__MODULE__{
+          kms_client: struct(),
+          region: String.t(),
+          discovery_filter: discovery_filter() | nil,
+          grant_tokens: [String.t()]
+        }
+
+  @enforce_keys [:kms_client, :region]
+  defstruct [:kms_client, :region, :discovery_filter, grant_tokens: []]
+
+  @provider_id "aws-kms"
+
+  @doc """
+  Creates a new AWS KMS MRK Discovery Keyring.
+
+  ## Parameters
+
+  - `kms_client` - KMS client struct implementing KmsClient behaviour
+  - `region` - AWS region string for this keyring (e.g., "us-west-2")
+  - `opts` - Optional keyword list:
+    - `:discovery_filter` - Map with `:partition` (string) and `:accounts` (list of strings)
+    - `:grant_tokens` - List of grant tokens for KMS API calls
+
+  ## Returns
+
+  - `{:ok, keyring}` on success
+  - `{:error, reason}` on validation failure
+
+  ## Examples
+
+      {:ok, client} = KmsClient.Mock.new(%{})
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(client, "us-west-2")
+
+      # With discovery filter
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(client, "us-west-2",
+        discovery_filter: %{partition: "aws", accounts: ["123456789012"]}
+      )
+
+  """
+  @spec new(struct(), String.t(), keyword()) :: {:ok, t()} | {:error, term()}
+  def new(kms_client, region, opts \\ []) do
+    with :ok <- validate_client(kms_client),
+         :ok <- validate_region(region),
+         :ok <- validate_discovery_filter(opts[:discovery_filter]) do
+      {:ok,
+       %__MODULE__{
+         kms_client: kms_client,
+         region: region,
+         discovery_filter: opts[:discovery_filter],
+         grant_tokens: Keyword.get(opts, :grant_tokens, [])
+       }}
+    end
+  end
+
+  defp validate_client(nil), do: {:error, :client_required}
+  defp validate_client(%{__struct__: _module}), do: :ok
+  defp validate_client(_invalid), do: {:error, :invalid_client_type}
+
+  defp validate_region(nil), do: {:error, :region_required}
+  defp validate_region(""), do: {:error, :region_empty}
+  defp validate_region(region) when is_binary(region), do: :ok
+  defp validate_region(_invalid), do: {:error, :invalid_region_type}
+
+  defp validate_discovery_filter(nil), do: :ok
+
+  defp validate_discovery_filter(%{partition: partition, accounts: accounts})
+       when is_binary(partition) and is_list(accounts) do
+    cond do
+      accounts == [] ->
+        {:error, :discovery_filter_accounts_empty}
+
+      not Enum.all?(accounts, &is_binary/1) ->
+        {:error, :invalid_account_ids}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_discovery_filter(_invalid), do: {:error, :invalid_discovery_filter}
+
+  @doc """
+  MRK Discovery keyrings cannot encrypt - this always fails.
+
+  ## Returns
+
+  Always returns `{:error, :discovery_keyring_cannot_encrypt}`
+  """
+  @spec wrap_key(t(), EncryptionMaterials.t()) :: {:error, :discovery_keyring_cannot_encrypt}
+  def wrap_key(%__MODULE__{}, %EncryptionMaterials{}) do
+    {:error, :discovery_keyring_cannot_encrypt}
+  end
+
+  @doc """
+  Unwraps a data key using AWS KMS MRK Discovery.
+
+  For MRK EDKs, reconstructs the ARN with the keyring's configured region
+  before calling KMS Decrypt, enabling cross-region decryption.
+
+  For non-MRK EDKs, filters out any where the region doesn't match.
+
+  ## Returns
+
+  - `{:ok, materials}` - Data key successfully decrypted
+  - `{:error, :plaintext_data_key_already_set}` - Materials already have key
+  - `{:error, {:unable_to_decrypt_any_data_key, errors}}` - All decryption attempts failed
+
+  ## Examples
+
+      {:ok, result} = AwsKmsMrkDiscovery.unwrap_key(keyring, materials, edks)
+
+  """
+  @spec unwrap_key(t(), DecryptionMaterials.t(), [EncryptedDataKey.t()]) ::
+          {:ok, DecryptionMaterials.t()} | {:error, term()}
+  def unwrap_key(%__MODULE__{} = keyring, %DecryptionMaterials{} = materials, edks) do
+    if KeyringBehaviour.has_plaintext_data_key?(materials) do
+      {:error, :plaintext_data_key_already_set}
+    else
+      try_decrypt_edks(keyring, materials, edks, [])
+    end
+  end
+
+  defp try_decrypt_edks(_keyring, _materials, [], errors) do
+    {:error, {:unable_to_decrypt_any_data_key, Enum.reverse(errors)}}
+  end
+
+  defp try_decrypt_edks(keyring, materials, [edk | rest], errors) do
+    case try_decrypt_edk(keyring, materials, edk) do
+      {:ok, plaintext} ->
+        DecryptionMaterials.set_plaintext_data_key(materials, plaintext)
+
+      {:error, reason} ->
+        try_decrypt_edks(keyring, materials, rest, [reason | errors])
+    end
+  end
+
+  defp try_decrypt_edk(keyring, materials, edk) do
+    with :ok <- match_provider_id(edk),
+         {:ok, arn} <- parse_provider_info_arn(edk),
+         :ok <- validate_resource_type_is_key(arn),
+         :ok <- passes_discovery_filter(keyring.discovery_filter, arn),
+         {:ok, decrypt_key_id} <- determine_decrypt_key_id(arn, keyring.region),
+         {:ok, plaintext} <- call_kms_decrypt(keyring, materials, edk, decrypt_key_id),
+         :ok <- validate_decrypted_length(plaintext, materials.algorithm_suite.kdf_input_length) do
+      {:ok, plaintext}
+    end
+  end
+
+  defp match_provider_id(%{key_provider_id: @provider_id}), do: :ok
+  defp match_provider_id(%{key_provider_id: id}), do: {:error, {:provider_id_mismatch, id}}
+
+  defp parse_provider_info_arn(edk) do
+    case KmsKeyArn.parse(edk.key_provider_info) do
+      {:ok, arn} -> {:ok, arn}
+      {:error, reason} -> {:error, {:invalid_provider_info_arn, reason}}
+    end
+  end
+
+  defp validate_resource_type_is_key(%{resource_type: "key"}), do: :ok
+
+  defp validate_resource_type_is_key(%{resource_type: type}),
+    do: {:error, {:invalid_resource_type, type}}
+
+  # Discovery filter matching (reused from base discovery)
+  defp passes_discovery_filter(nil, _arn), do: :ok
+
+  defp passes_discovery_filter(%{partition: filter_partition, accounts: filter_accounts}, arn) do
+    with :ok <- match_partition(filter_partition, arn.partition) do
+      match_account(filter_accounts, arn.account)
+    end
+  end
+
+  defp match_partition(filter_partition, arn_partition) when filter_partition == arn_partition,
+    do: :ok
+
+  defp match_partition(filter_partition, arn_partition) do
+    {:error, {:partition_mismatch, expected: filter_partition, actual: arn_partition}}
+  end
+
+  defp match_account(filter_accounts, arn_account) do
+    if arn_account in filter_accounts do
+      :ok
+    else
+      {:error, {:account_not_in_filter, account: arn_account, allowed: filter_accounts}}
+    end
+  end
+
+  # KEY DIFFERENTIATOR: MRK-aware region handling
+  defp determine_decrypt_key_id(arn, region) do
+    if KmsKeyArn.mrk?(arn) do
+      # MRK: Reconstruct ARN with configured region
+      reconstructed = %{arn | region: region}
+      {:ok, KmsKeyArn.to_string(reconstructed)}
+    else
+      # Non-MRK: Must be in same region
+      if arn.region == region do
+        {:ok, KmsKeyArn.to_string(arn)}
+      else
+        {:error, {:non_mrk_region_mismatch, expected: region, actual: arn.region}}
+      end
+    end
+  end
+
+  defp call_kms_decrypt(keyring, materials, edk, decrypt_key_id) do
+    client_module = keyring.kms_client.__struct__
+
+    result =
+      client_module.decrypt(
+        keyring.kms_client,
+        decrypt_key_id,
+        edk.ciphertext,
+        materials.encryption_context,
+        keyring.grant_tokens
+      )
+
+    with {:ok, response} <- result,
+         :ok <- verify_response_key_id(decrypt_key_id, response.key_id) do
+      {:ok, response.plaintext}
+    end
+  end
+
+  # MRK Discovery uses exact comparison (we already reconstructed the ARN)
+  defp verify_response_key_id(expected, actual) when expected == actual, do: :ok
+
+  defp verify_response_key_id(expected, actual) do
+    {:error, {:response_key_id_mismatch, expected, actual}}
+  end
+
+  defp validate_decrypted_length(plaintext, expected) when byte_size(plaintext) == expected,
+    do: :ok
+
+  defp validate_decrypted_length(plaintext, expected) do
+    {:error, {:invalid_decrypted_length, expected: expected, actual: byte_size(plaintext)}}
+  end
+
+  # Behaviour callbacks
+  @impl AwsEncryptionSdk.Keyring.Behaviour
+  def on_encrypt(_materials) do
+    {:error, {:must_use_wrap_key, "Call AwsKmsMrkDiscovery.wrap_key(keyring, materials) instead"}}
+  end
+
+  @impl AwsEncryptionSdk.Keyring.Behaviour
+  def on_decrypt(_materials, _encrypted_data_keys) do
+    {:error,
+     {:must_use_unwrap_key,
+      "Call AwsKmsMrkDiscovery.unwrap_key(keyring, materials, edks) instead"}}
+  end
+end

--- a/lib/aws_encryption_sdk/keyring/multi.ex
+++ b/lib/aws_encryption_sdk/keyring/multi.ex
@@ -52,7 +52,15 @@ defmodule AwsEncryptionSdk.Keyring.Multi do
 
   @behaviour AwsEncryptionSdk.Keyring.Behaviour
 
-  alias AwsEncryptionSdk.Keyring.{AwsKms, AwsKmsDiscovery, AwsKmsMrk, RawAes, RawRsa}
+  alias AwsEncryptionSdk.Keyring.{
+    AwsKms,
+    AwsKmsDiscovery,
+    AwsKmsMrk,
+    AwsKmsMrkDiscovery,
+    RawAes,
+    RawRsa
+  }
+
   alias AwsEncryptionSdk.Keyring.Behaviour, as: KeyringBehaviour
   alias AwsEncryptionSdk.Materials.{DecryptionMaterials, EncryptedDataKey, EncryptionMaterials}
 
@@ -228,6 +236,10 @@ defmodule AwsEncryptionSdk.Keyring.Multi do
     AwsKmsMrk.wrap_key(keyring, materials)
   end
 
+  defp call_wrap_key(%AwsKmsMrkDiscovery{} = keyring, materials) do
+    AwsKmsMrkDiscovery.wrap_key(keyring, materials)
+  end
+
   defp call_wrap_key(%__MODULE__{} = keyring, materials) do
     # Nested multi-keyring
     wrap_key(keyring, materials)
@@ -306,6 +318,10 @@ defmodule AwsEncryptionSdk.Keyring.Multi do
 
   defp call_unwrap_key(%AwsKmsMrk{} = keyring, materials, edks) do
     AwsKmsMrk.unwrap_key(keyring, materials, edks)
+  end
+
+  defp call_unwrap_key(%AwsKmsMrkDiscovery{} = keyring, materials, edks) do
+    AwsKmsMrkDiscovery.unwrap_key(keyring, materials, edks)
   end
 
   defp call_unwrap_key(%__MODULE__{} = keyring, materials, edks) do

--- a/test/aws_encryption_sdk/algorithm_suite_test.exs
+++ b/test/aws_encryption_sdk/algorithm_suite_test.exs
@@ -1,6 +1,8 @@
 defmodule AwsEncryptionSdk.AlgorithmSuiteTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog
+
   alias AwsEncryptionSdk.AlgorithmSuite
 
   describe "default/0" do
@@ -116,39 +118,47 @@ defmodule AwsEncryptionSdk.AlgorithmSuiteTest do
     ]
 
     test "all 11 ESDK suites are accessible via by_id/1" do
-      for suite_id <- @all_suite_ids do
-        assert {:ok, suite} = AlgorithmSuite.by_id(suite_id)
-        assert suite.id == suite_id
-      end
+      capture_log(fn ->
+        for suite_id <- @all_suite_ids do
+          assert {:ok, suite} = AlgorithmSuite.by_id(suite_id)
+          assert suite.id == suite_id
+        end
+      end)
     end
 
     test "all suites have required fields" do
-      for suite_id <- @all_suite_ids do
-        {:ok, suite} = AlgorithmSuite.by_id(suite_id)
+      capture_log(fn ->
+        for suite_id <- @all_suite_ids do
+          {:ok, suite} = AlgorithmSuite.by_id(suite_id)
 
-        assert is_integer(suite.id)
-        assert is_binary(suite.name)
-        assert suite.message_format_version in [1, 2]
-        assert suite.encryption_algorithm in [:aes_128_gcm, :aes_192_gcm, :aes_256_gcm]
-        assert suite.data_key_length in [128, 192, 256]
-        assert suite.iv_length == 12
-        assert suite.auth_tag_length == 16
-        assert suite.kdf_type in [:hkdf, :identity]
-      end
+          assert is_integer(suite.id)
+          assert is_binary(suite.name)
+          assert suite.message_format_version in [1, 2]
+          assert suite.encryption_algorithm in [:aes_128_gcm, :aes_192_gcm, :aes_256_gcm]
+          assert suite.data_key_length in [128, 192, 256]
+          assert suite.iv_length == 12
+          assert suite.auth_tag_length == 16
+          assert suite.kdf_type in [:hkdf, :identity]
+        end
+      end)
     end
 
     test "all suites have consistent iv_length of 12" do
-      for suite_id <- @all_suite_ids do
-        {:ok, suite} = AlgorithmSuite.by_id(suite_id)
-        assert suite.iv_length == 12
-      end
+      capture_log(fn ->
+        for suite_id <- @all_suite_ids do
+          {:ok, suite} = AlgorithmSuite.by_id(suite_id)
+          assert suite.iv_length == 12
+        end
+      end)
     end
 
     test "all suites have consistent auth_tag_length of 16" do
-      for suite_id <- @all_suite_ids do
-        {:ok, suite} = AlgorithmSuite.by_id(suite_id)
-        assert suite.auth_tag_length == 16
-      end
+      capture_log(fn ->
+        for suite_id <- @all_suite_ids do
+          {:ok, suite} = AlgorithmSuite.by_id(suite_id)
+          assert suite.auth_tag_length == 16
+        end
+      end)
     end
   end
 
@@ -180,12 +190,14 @@ defmodule AwsEncryptionSdk.AlgorithmSuiteTest do
     end
 
     test "unsigned suites have no signature algorithm" do
-      for suite_id <- @unsigned_suite_ids do
-        {:ok, suite} = AlgorithmSuite.by_id(suite_id)
-        refute AlgorithmSuite.signed?(suite)
-        assert suite.signature_algorithm == nil
-        assert suite.signature_hash == nil
-      end
+      capture_log(fn ->
+        for suite_id <- @unsigned_suite_ids do
+          {:ok, suite} = AlgorithmSuite.by_id(suite_id)
+          refute AlgorithmSuite.signed?(suite)
+          assert suite.signature_algorithm == nil
+          assert suite.signature_hash == nil
+        end
+      end)
     end
   end
 
@@ -194,13 +206,15 @@ defmodule AwsEncryptionSdk.AlgorithmSuiteTest do
     @non_deprecated_suite_ids [0x0578, 0x0478, 0x0378, 0x0346, 0x0214, 0x0178, 0x0146, 0x0114]
 
     test "NO_KDF suites are deprecated" do
-      for suite_id <- @deprecated_suite_ids do
-        {:ok, suite} = AlgorithmSuite.by_id(suite_id)
-        assert AlgorithmSuite.deprecated?(suite)
-        refute AlgorithmSuite.allows_encryption?(suite)
-        assert suite.kdf_type == :identity
-        assert suite.kdf_hash == nil
-      end
+      capture_log(fn ->
+        for suite_id <- @deprecated_suite_ids do
+          {:ok, suite} = AlgorithmSuite.by_id(suite_id)
+          assert AlgorithmSuite.deprecated?(suite)
+          refute AlgorithmSuite.allows_encryption?(suite)
+          assert suite.kdf_type == :identity
+          assert suite.kdf_hash == nil
+        end
+      end)
     end
 
     test "HKDF suites are not deprecated" do
@@ -212,8 +226,6 @@ defmodule AwsEncryptionSdk.AlgorithmSuiteTest do
         assert suite.kdf_hash != nil
       end
     end
-
-    import ExUnit.CaptureLog
 
     test "accessing deprecated suite logs warning" do
       log =
@@ -242,10 +254,12 @@ defmodule AwsEncryptionSdk.AlgorithmSuiteTest do
     end
 
     test "kdf_input_length matches data_key_length in bytes" do
-      for suite_id <- [0x0578, 0x0478, 0x0378, 0x0178, 0x0078] do
-        {:ok, suite} = AlgorithmSuite.by_id(suite_id)
-        assert suite.kdf_input_length == div(suite.data_key_length, 8)
-      end
+      capture_log(fn ->
+        for suite_id <- [0x0578, 0x0478, 0x0378, 0x0178, 0x0078] do
+          {:ok, suite} = AlgorithmSuite.by_id(suite_id)
+          assert suite.kdf_input_length == div(suite.data_key_length, 8)
+        end
+      end)
     end
   end
 

--- a/test/aws_encryption_sdk/keyring/aws_kms_mrk_discovery_test.exs
+++ b/test/aws_encryption_sdk/keyring/aws_kms_mrk_discovery_test.exs
@@ -1,0 +1,477 @@
+defmodule AwsEncryptionSdk.Keyring.AwsKmsMrkDiscoveryTest do
+  use ExUnit.Case, async: true
+
+  alias AwsEncryptionSdk.AlgorithmSuite
+  alias AwsEncryptionSdk.Cmm.Default, as: DefaultCmm
+  alias AwsEncryptionSdk.Keyring.{AwsKmsMrkDiscovery, Multi}
+  alias AwsEncryptionSdk.Keyring.KmsClient.Mock
+  alias AwsEncryptionSdk.Materials.{DecryptionMaterials, EncryptedDataKey, EncryptionMaterials}
+
+  @mrk_us_west "arn:aws:kms:us-west-2:123456789012:key/mrk-12345678123456781234567812345678"
+  @mrk_us_east "arn:aws:kms:us-east-1:123456789012:key/mrk-12345678123456781234567812345678"
+  @non_mrk_us_west "arn:aws:kms:us-west-2:123456789012:key/12345678-1234-1234-1234-123456789012"
+  @non_mrk_us_east "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+
+  describe "new/3" do
+    test "creates keyring with valid inputs" do
+      {:ok, mock} = Mock.new()
+      assert {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2")
+      assert keyring.kms_client == mock
+      assert keyring.region == "us-west-2"
+      assert keyring.discovery_filter == nil
+      assert keyring.grant_tokens == []
+    end
+
+    test "stores discovery filter and grant tokens" do
+      {:ok, mock} = Mock.new()
+      filter = %{partition: "aws", accounts: ["123456789012"]}
+
+      {:ok, keyring} =
+        AwsKmsMrkDiscovery.new(mock, "us-west-2",
+          discovery_filter: filter,
+          grant_tokens: ["token1"]
+        )
+
+      assert keyring.discovery_filter == filter
+      assert keyring.grant_tokens == ["token1"]
+    end
+
+    test "rejects nil client" do
+      assert {:error, :client_required} = AwsKmsMrkDiscovery.new(nil, "us-west-2")
+    end
+
+    test "rejects nil region" do
+      {:ok, mock} = Mock.new()
+      assert {:error, :region_required} = AwsKmsMrkDiscovery.new(mock, nil)
+    end
+
+    test "rejects empty region" do
+      {:ok, mock} = Mock.new()
+      assert {:error, :region_empty} = AwsKmsMrkDiscovery.new(mock, "")
+    end
+
+    test "rejects invalid discovery filter" do
+      {:ok, mock} = Mock.new()
+
+      assert {:error, :invalid_discovery_filter} =
+               AwsKmsMrkDiscovery.new(mock, "us-west-2", discovery_filter: %{partition: "aws"})
+    end
+
+    test "rejects invalid client type (not a struct)" do
+      assert {:error, :invalid_client_type} = AwsKmsMrkDiscovery.new("not-a-struct", "us-west-2")
+    end
+
+    test "rejects invalid region type (not a string)" do
+      {:ok, mock} = Mock.new()
+      assert {:error, :invalid_region_type} = AwsKmsMrkDiscovery.new(mock, 123)
+    end
+
+    test "rejects discovery filter with empty accounts list" do
+      {:ok, mock} = Mock.new()
+
+      assert {:error, :discovery_filter_accounts_empty} =
+               AwsKmsMrkDiscovery.new(mock, "us-west-2",
+                 discovery_filter: %{partition: "aws", accounts: []}
+               )
+    end
+
+    test "rejects discovery filter with non-string account ids" do
+      {:ok, mock} = Mock.new()
+
+      assert {:error, :invalid_account_ids} =
+               AwsKmsMrkDiscovery.new(mock, "us-west-2",
+                 discovery_filter: %{partition: "aws", accounts: [123, 456]}
+               )
+    end
+  end
+
+  describe "wrap_key/2" do
+    test "always fails - discovery keyrings cannot encrypt" do
+      {:ok, mock} = Mock.new()
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2")
+
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      materials = EncryptionMaterials.new_for_encrypt(suite, %{})
+
+      assert {:error, :discovery_keyring_cannot_encrypt} =
+               AwsKmsMrkDiscovery.wrap_key(keyring, materials)
+    end
+  end
+
+  describe "unwrap_key/3 - error cases" do
+    test "fails when materials already have plaintext data key" do
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      plaintext_key = :crypto.strong_rand_bytes(32)
+      ciphertext = :crypto.strong_rand_bytes(128)
+
+      {:ok, mock} = Mock.new()
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2")
+
+      # Create materials that already have a plaintext data key
+      materials = DecryptionMaterials.new_for_decrypt(suite, %{})
+
+      {:ok, materials_with_key} =
+        DecryptionMaterials.set_plaintext_data_key(materials, plaintext_key)
+
+      edk = EncryptedDataKey.new("aws-kms", @mrk_us_west, ciphertext)
+
+      assert {:error, :plaintext_data_key_already_set} =
+               AwsKmsMrkDiscovery.unwrap_key(keyring, materials_with_key, [edk])
+    end
+
+    test "fails when provider ID doesn't match" do
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      ciphertext = :crypto.strong_rand_bytes(128)
+
+      {:ok, mock} = Mock.new()
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2")
+      materials = DecryptionMaterials.new_for_decrypt(suite, %{})
+
+      # EDK with wrong provider ID
+      edk = EncryptedDataKey.new("wrong-provider", @mrk_us_west, ciphertext)
+
+      assert {:error, {:unable_to_decrypt_any_data_key, errors}} =
+               AwsKmsMrkDiscovery.unwrap_key(keyring, materials, [edk])
+
+      assert [{:provider_id_mismatch, "wrong-provider"}] = errors
+    end
+
+    test "fails when provider info is not a valid ARN" do
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      ciphertext = :crypto.strong_rand_bytes(128)
+
+      {:ok, mock} = Mock.new()
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2")
+      materials = DecryptionMaterials.new_for_decrypt(suite, %{})
+
+      # EDK with invalid ARN as provider info
+      edk = EncryptedDataKey.new("aws-kms", "not-an-arn", ciphertext)
+
+      assert {:error, {:unable_to_decrypt_any_data_key, errors}} =
+               AwsKmsMrkDiscovery.unwrap_key(keyring, materials, [edk])
+
+      assert [{:invalid_provider_info_arn, _reason}] = errors
+    end
+
+    test "fails when resource type is alias instead of key" do
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      ciphertext = :crypto.strong_rand_bytes(128)
+
+      {:ok, mock} = Mock.new()
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2")
+      materials = DecryptionMaterials.new_for_decrypt(suite, %{})
+
+      # EDK with alias resource type
+      alias_arn = "arn:aws:kms:us-west-2:123456789012:alias/my-alias"
+      edk = EncryptedDataKey.new("aws-kms", alias_arn, ciphertext)
+
+      assert {:error, {:unable_to_decrypt_any_data_key, errors}} =
+               AwsKmsMrkDiscovery.unwrap_key(keyring, materials, [edk])
+
+      assert [{:invalid_resource_type, "alias"}] = errors
+    end
+
+    test "fails when partition doesn't match discovery filter" do
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      ciphertext = :crypto.strong_rand_bytes(128)
+
+      {:ok, mock} = Mock.new()
+
+      {:ok, keyring} =
+        AwsKmsMrkDiscovery.new(mock, "us-west-2",
+          discovery_filter: %{partition: "aws-cn", accounts: ["123456789012"]}
+        )
+
+      materials = DecryptionMaterials.new_for_decrypt(suite, %{})
+      edk = EncryptedDataKey.new("aws-kms", @mrk_us_west, ciphertext)
+
+      assert {:error, {:unable_to_decrypt_any_data_key, errors}} =
+               AwsKmsMrkDiscovery.unwrap_key(keyring, materials, [edk])
+
+      assert [{:partition_mismatch, expected: "aws-cn", actual: "aws"}] = errors
+    end
+
+    test "fails when KMS returns mismatched key ID" do
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      plaintext_key = :crypto.strong_rand_bytes(32)
+      ciphertext = :crypto.strong_rand_bytes(128)
+
+      # KMS returns a different key ID than expected
+      {:ok, mock} =
+        Mock.new(%{
+          {:decrypt, @mrk_us_west} => %{
+            plaintext: plaintext_key,
+            key_id: "arn:aws:kms:us-west-2:123456789012:key/different-key-id"
+          }
+        })
+
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2")
+      materials = DecryptionMaterials.new_for_decrypt(suite, %{})
+      edk = EncryptedDataKey.new("aws-kms", @mrk_us_west, ciphertext)
+
+      assert {:error, {:unable_to_decrypt_any_data_key, errors}} =
+               AwsKmsMrkDiscovery.unwrap_key(keyring, materials, [edk])
+
+      assert [{:response_key_id_mismatch, @mrk_us_west, _actual}] = errors
+    end
+
+    test "fails when decrypted key has wrong length" do
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      # Return wrong length key (16 bytes instead of 32)
+      wrong_length_key = :crypto.strong_rand_bytes(16)
+      ciphertext = :crypto.strong_rand_bytes(128)
+
+      {:ok, mock} =
+        Mock.new(%{
+          {:decrypt, @mrk_us_west} => %{
+            plaintext: wrong_length_key,
+            key_id: @mrk_us_west
+          }
+        })
+
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2")
+      materials = DecryptionMaterials.new_for_decrypt(suite, %{})
+      edk = EncryptedDataKey.new("aws-kms", @mrk_us_west, ciphertext)
+
+      assert {:error, {:unable_to_decrypt_any_data_key, errors}} =
+               AwsKmsMrkDiscovery.unwrap_key(keyring, materials, [edk])
+
+      assert [{:invalid_decrypted_length, expected: 32, actual: 16}] = errors
+    end
+  end
+
+  describe "unwrap_key/3 - MRK same region" do
+    test "decrypts MRK EDK when regions match" do
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      plaintext_key = :crypto.strong_rand_bytes(32)
+      ciphertext = :crypto.strong_rand_bytes(128)
+
+      {:ok, mock} =
+        Mock.new(%{
+          {:decrypt, @mrk_us_west} => %{
+            plaintext: plaintext_key,
+            key_id: @mrk_us_west
+          }
+        })
+
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2")
+      materials = DecryptionMaterials.new_for_decrypt(suite, %{})
+      edk = EncryptedDataKey.new("aws-kms", @mrk_us_west, ciphertext)
+
+      {:ok, result} = AwsKmsMrkDiscovery.unwrap_key(keyring, materials, [edk])
+      assert result.plaintext_data_key == plaintext_key
+    end
+  end
+
+  describe "unwrap_key/3 - MRK cross-region (KEY VALUE PROPOSITION)" do
+    test "decrypts us-east-1 MRK EDK with us-west-2 keyring" do
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      plaintext_key = :crypto.strong_rand_bytes(32)
+      ciphertext = :crypto.strong_rand_bytes(128)
+
+      # KMS in us-west-2 receives decrypt call with reconstructed ARN
+      reconstructed_arn =
+        "arn:aws:kms:us-west-2:123456789012:key/mrk-12345678123456781234567812345678"
+
+      {:ok, mock} =
+        Mock.new(%{
+          {:decrypt, reconstructed_arn} => %{
+            plaintext: plaintext_key,
+            key_id: reconstructed_arn
+          }
+        })
+
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2")
+      materials = DecryptionMaterials.new_for_decrypt(suite, %{})
+      # EDK from us-east-1 (different region!)
+      edk = EncryptedDataKey.new("aws-kms", @mrk_us_east, ciphertext)
+
+      {:ok, result} = AwsKmsMrkDiscovery.unwrap_key(keyring, materials, [edk])
+      assert result.plaintext_data_key == plaintext_key
+    end
+
+    test "decrypts us-west-2 MRK EDK with us-east-1 keyring" do
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      plaintext_key = :crypto.strong_rand_bytes(32)
+      ciphertext = :crypto.strong_rand_bytes(128)
+
+      reconstructed_arn =
+        "arn:aws:kms:us-east-1:123456789012:key/mrk-12345678123456781234567812345678"
+
+      {:ok, mock} =
+        Mock.new(%{
+          {:decrypt, reconstructed_arn} => %{
+            plaintext: plaintext_key,
+            key_id: reconstructed_arn
+          }
+        })
+
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-east-1")
+      materials = DecryptionMaterials.new_for_decrypt(suite, %{})
+      edk = EncryptedDataKey.new("aws-kms", @mrk_us_west, ciphertext)
+
+      {:ok, result} = AwsKmsMrkDiscovery.unwrap_key(keyring, materials, [edk])
+      assert result.plaintext_data_key == plaintext_key
+    end
+  end
+
+  describe "unwrap_key/3 - non-MRK region filtering" do
+    test "decrypts non-MRK EDK when region matches" do
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      plaintext_key = :crypto.strong_rand_bytes(32)
+      ciphertext = :crypto.strong_rand_bytes(128)
+
+      {:ok, mock} =
+        Mock.new(%{
+          {:decrypt, @non_mrk_us_west} => %{
+            plaintext: plaintext_key,
+            key_id: @non_mrk_us_west
+          }
+        })
+
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2")
+      materials = DecryptionMaterials.new_for_decrypt(suite, %{})
+      edk = EncryptedDataKey.new("aws-kms", @non_mrk_us_west, ciphertext)
+
+      {:ok, result} = AwsKmsMrkDiscovery.unwrap_key(keyring, materials, [edk])
+      assert result.plaintext_data_key == plaintext_key
+    end
+
+    test "filters out non-MRK EDK from different region" do
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      ciphertext = :crypto.strong_rand_bytes(128)
+
+      {:ok, mock} = Mock.new()
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2")
+      materials = DecryptionMaterials.new_for_decrypt(suite, %{})
+      # EDK from us-east-1 non-MRK
+      edk = EncryptedDataKey.new("aws-kms", @non_mrk_us_east, ciphertext)
+
+      assert {:error, {:unable_to_decrypt_any_data_key, errors}} =
+               AwsKmsMrkDiscovery.unwrap_key(keyring, materials, [edk])
+
+      assert [{:non_mrk_region_mismatch, expected: "us-west-2", actual: "us-east-1"}] = errors
+    end
+  end
+
+  describe "unwrap_key/3 - discovery filter with MRK" do
+    test "applies filter before MRK reconstruction" do
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      ciphertext = :crypto.strong_rand_bytes(128)
+
+      {:ok, mock} = Mock.new()
+
+      {:ok, keyring} =
+        AwsKmsMrkDiscovery.new(mock, "us-west-2",
+          discovery_filter: %{partition: "aws", accounts: ["999999999999"]}
+        )
+
+      materials = DecryptionMaterials.new_for_decrypt(suite, %{})
+      edk = EncryptedDataKey.new("aws-kms", @mrk_us_east, ciphertext)
+
+      assert {:error, {:unable_to_decrypt_any_data_key, errors}} =
+               AwsKmsMrkDiscovery.unwrap_key(keyring, materials, [edk])
+
+      assert [{:account_not_in_filter, account: "123456789012", allowed: ["999999999999"]}] =
+               errors
+    end
+
+    test "MRK cross-region works with matching filter" do
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      plaintext_key = :crypto.strong_rand_bytes(32)
+      ciphertext = :crypto.strong_rand_bytes(128)
+
+      reconstructed_arn =
+        "arn:aws:kms:us-west-2:123456789012:key/mrk-12345678123456781234567812345678"
+
+      {:ok, mock} =
+        Mock.new(%{
+          {:decrypt, reconstructed_arn} => %{
+            plaintext: plaintext_key,
+            key_id: reconstructed_arn
+          }
+        })
+
+      {:ok, keyring} =
+        AwsKmsMrkDiscovery.new(mock, "us-west-2",
+          discovery_filter: %{partition: "aws", accounts: ["123456789012"]}
+        )
+
+      materials = DecryptionMaterials.new_for_decrypt(suite, %{})
+      edk = EncryptedDataKey.new("aws-kms", @mrk_us_east, ciphertext)
+
+      {:ok, result} = AwsKmsMrkDiscovery.unwrap_key(keyring, materials, [edk])
+      assert result.plaintext_data_key == plaintext_key
+    end
+  end
+
+  describe "integration with Default CMM" do
+    test "CMM decrypt uses MRK discovery keyring" do
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      plaintext_key = :crypto.strong_rand_bytes(32)
+      ciphertext = :crypto.strong_rand_bytes(128)
+
+      {:ok, mock} =
+        Mock.new(%{
+          {:decrypt, @mrk_us_west} => %{
+            plaintext: plaintext_key,
+            key_id: @mrk_us_west
+          }
+        })
+
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2")
+      cmm = DefaultCmm.new(keyring)
+
+      edk = EncryptedDataKey.new("aws-kms", @mrk_us_west, ciphertext)
+
+      request = %{
+        algorithm_suite: suite,
+        encryption_context: %{},
+        encrypted_data_keys: [edk],
+        commitment_policy: :require_encrypt_require_decrypt
+      }
+
+      {:ok, materials} = DefaultCmm.get_decryption_materials(cmm, request)
+      assert materials.plaintext_data_key == plaintext_key
+    end
+
+    test "CMM encrypt fails with MRK discovery keyring" do
+      {:ok, mock} = Mock.new()
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2")
+      cmm = DefaultCmm.new(keyring)
+
+      request = %{encryption_context: %{}, commitment_policy: :require_encrypt_require_decrypt}
+
+      assert {:error, :discovery_keyring_cannot_encrypt} =
+               DefaultCmm.get_encryption_materials(cmm, request)
+    end
+  end
+
+  describe "integration with Multi-keyring" do
+    test "multi-keyring can use MRK discovery keyring for decrypt" do
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      plaintext_key = :crypto.strong_rand_bytes(32)
+      ciphertext = :crypto.strong_rand_bytes(128)
+
+      reconstructed_arn =
+        "arn:aws:kms:us-west-2:123456789012:key/mrk-12345678123456781234567812345678"
+
+      {:ok, mock} =
+        Mock.new(%{
+          {:decrypt, reconstructed_arn} => %{
+            plaintext: plaintext_key,
+            key_id: reconstructed_arn
+          }
+        })
+
+      {:ok, discovery_keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2")
+      {:ok, multi} = Multi.new(children: [discovery_keyring])
+
+      materials = DecryptionMaterials.new_for_decrypt(suite, %{})
+      edk = EncryptedDataKey.new("aws-kms", @mrk_us_east, ciphertext)
+
+      {:ok, result} = Multi.unwrap_key(multi, materials, [edk])
+      assert result.plaintext_data_key == plaintext_key
+    end
+  end
+end

--- a/test/aws_encryption_sdk/keyring/aws_kms_test.exs
+++ b/test/aws_encryption_sdk/keyring/aws_kms_test.exs
@@ -427,7 +427,7 @@ defmodule AwsEncryptionSdk.Keyring.AwsKmsTest do
   describe "behaviour callbacks" do
     test "on_encrypt returns error directing to wrap_key" do
       {:ok, mock} = Mock.new()
-      {:ok, keyring} = AwsKms.new(@kms_key_arn, mock)
+      {:ok, _keyring} = AwsKms.new(@kms_key_arn, mock)
 
       suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
       materials = EncryptionMaterials.new_for_encrypt(suite, %{})
@@ -438,7 +438,7 @@ defmodule AwsEncryptionSdk.Keyring.AwsKmsTest do
 
     test "on_decrypt returns error directing to unwrap_key" do
       {:ok, mock} = Mock.new()
-      {:ok, keyring} = AwsKms.new(@kms_key_arn, mock)
+      {:ok, _keyring} = AwsKms.new(@kms_key_arn, mock)
 
       suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
       materials = DecryptionMaterials.new_for_decrypt(suite, %{})

--- a/thoughts/shared/plans/2026-01-28-GH51-aws-kms-mrk-discovery-keyring.md
+++ b/thoughts/shared/plans/2026-01-28-GH51-aws-kms-mrk-discovery-keyring.md
@@ -1,0 +1,852 @@
+# AWS KMS MRK Discovery Keyring Implementation Plan
+
+## Overview
+
+Implement the AWS KMS Multi-Region Key (MRK) Discovery Keyring - a decrypt-only keyring that combines discovery keyring behavior with MRK awareness. Unlike the basic discovery keyring that uses exact ARN matching, the MRK Discovery Keyring reconstructs ARNs with the configured region for MRK keys, enabling cross-region decryption, while filtering out non-MRK keys from different regions.
+
+**Issue**: #51
+**Research**: `thoughts/shared/research/2026-01-28-GH51-aws-kms-mrk-discovery-keyring.md`
+
+## Specification Requirements
+
+### Source Documents
+- [aws-kms-mrk-discovery-keyring.md](https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/framework/aws-kms/aws-kms-mrk-discovery-keyring.md) - Primary specification
+- [aws-kms-discovery-keyring.md](https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/framework/aws-kms/aws-kms-discovery-keyring.md) - Base discovery behavior
+- [aws-kms-mrk-match-for-decrypt.md](https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/framework/aws-kms/aws-kms-mrk-match-for-decrypt.md) - MRK matching algorithm
+
+### Key Requirements
+
+| Requirement | Spec Section | Type |
+|-------------|--------------|------|
+| Accept KMS client, region string, optional discovery filter, optional grant tokens | Constructor | MUST |
+| KMS client MUST NOT be null | Constructor | MUST |
+| Region MUST NOT be null or empty | Constructor | MUST |
+| Discovery filter validation (both partition and accounts required) | Constructor | MUST |
+| OnEncrypt MUST fail | OnEncrypt | MUST |
+| Early return if materials already have plaintext data key | OnDecrypt | MUST |
+| Filter EDKs by provider ID = "aws-kms" | OnDecrypt | MUST |
+| Filter EDKs by valid ARN with resource type "key" | OnDecrypt | MUST |
+| Apply discovery filter (partition/account matching) | OnDecrypt | MUST |
+| **For MRK: Reconstruct ARN with configured region** | OnDecrypt | MUST |
+| **For non-MRK: Filter out if region doesn't match** | OnDecrypt | MUST |
+| Validate response KeyId matches request KeyId | OnDecrypt | MUST |
+| Validate plaintext length matches algorithm suite | OnDecrypt | MUST |
+| Collect errors and continue to next EDK on failure | OnDecrypt | MUST |
+| Region should match KMS client region | Constructor | SHOULD |
+
+## Test Vectors
+
+### Validation Strategy
+Unit tests with mock KMS client for MRK-specific scenarios. The test vectors for MRK discovery keyrings require cross-region KMS access which is validated through mocked scenarios.
+
+### Test Scenarios Summary
+
+| Phase | Scenario | Purpose |
+|-------|----------|---------|
+| 1 | Constructor validation | Region required, client required, filter validation |
+| 2 | Basic MRK same region | MRK decrypt without region reconstruction |
+| 3 | Cross-region MRK | **Core value** - reconstruct ARN with configured region |
+| 4 | Non-MRK filtering | Filter out non-MRK keys from different regions |
+| 5 | Discovery filter + MRK | Filter applied before MRK reconstruction |
+
+## Current State Analysis
+
+### Key Discoveries:
+
+1. **`AwsKmsDiscovery` (`lib/aws_encryption_sdk/keyring/aws_kms_discovery.ex`)** provides the base pattern:
+   - Struct: `kms_client`, `discovery_filter`, `grant_tokens`
+   - `wrap_key/2` returns `{:error, :discovery_keyring_cannot_encrypt}`
+   - `unwrap_key/3` filters EDKs, calls KMS, validates response
+   - Uses **exact** KeyId comparison at line 228
+
+2. **`KmsKeyArn` (`lib/aws_encryption_sdk/keyring/kms_key_arn.ex`)** has all MRK utilities:
+   - `mrk?/1` - checks if identifier is MRK (mrk- prefix)
+   - `to_string/1` - reconstructs ARN from struct
+   - Struct update `%{arn | region: region}` supported
+
+3. **CMM dispatch** (`lib/aws_encryption_sdk/cmm/default.ex:37`) needs alias and clauses added
+4. **Multi-keyring dispatch** (`lib/aws_encryption_sdk/keyring/multi.ex:55`) needs alias and clauses added
+
+## Desired End State
+
+After implementation:
+
+1. `AwsKmsMrkDiscovery` module exists at `lib/aws_encryption_sdk/keyring/aws_kms_mrk_discovery.ex`
+2. Keyring can decrypt EDKs encrypted with MRKs from any region
+3. Keyring filters out non-MRK EDKs from different regions
+4. CMM and Multi-keyring dispatch support the new keyring type
+5. All tests pass: `mix quality`
+
+**Verification Command**: `mix test test/aws_encryption_sdk/keyring/aws_kms_mrk_discovery_test.exs`
+
+## What We're NOT Doing
+
+- AWS KMS MRK Discovery Multi-Keyring (convenience constructor) - separate issue
+- Real KMS integration tests (requires AWS credentials)
+- Streaming decryption support
+- Region validation against client (SHOULD requirement - defer to later)
+
+## Implementation Approach
+
+Copy `AwsKmsDiscovery` as the base and modify for MRK awareness:
+
+1. Add `region` field (required) to struct
+2. Add region validation in constructor
+3. Add `determine_decrypt_key_id/2` for MRK ARN reconstruction
+4. Modify `call_kms_decrypt/3` to use determined key ID
+5. Keep response validation as exact match (using reconstructed ARN)
+
+---
+
+## Phase 1: Core Module Structure
+
+### Overview
+Create the `AwsKmsMrkDiscovery` module with struct, constructor, and `wrap_key/2` (encryption prohibition).
+
+### Spec Requirements Addressed
+- KMS client MUST NOT be null
+- Region MUST NOT be null or empty
+- Discovery filter validation
+- OnEncrypt MUST fail
+
+### Changes Required:
+
+#### 1. Create MRK Discovery Keyring Module
+**File**: `lib/aws_encryption_sdk/keyring/aws_kms_mrk_discovery.ex`
+**Changes**: Create new file based on AwsKmsDiscovery pattern
+
+```elixir
+defmodule AwsEncryptionSdk.Keyring.AwsKmsMrkDiscovery do
+  @moduledoc """
+  AWS KMS MRK Discovery Keyring implementation.
+
+  A decrypt-only keyring that combines discovery keyring behavior with MRK awareness.
+  For MRK keys, it reconstructs the ARN with the configured region, enabling
+  cross-region decryption. For non-MRK keys, it filters out EDKs where the
+  region doesn't match.
+
+  ## Example
+
+      {:ok, client} = KmsClient.ExAws.new(region: "us-west-2")
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(client, "us-west-2")
+
+      # Can decrypt MRK-encrypted data from ANY region
+      {:ok, materials} = AwsKmsMrkDiscovery.unwrap_key(keyring, materials, edks)
+
+  ## Spec Reference
+
+  https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/framework/aws-kms/aws-kms-mrk-discovery-keyring.md
+  """
+
+  @behaviour AwsEncryptionSdk.Keyring.Behaviour
+
+  alias AwsEncryptionSdk.Keyring.Behaviour, as: KeyringBehaviour
+  alias AwsEncryptionSdk.Keyring.KmsKeyArn
+  alias AwsEncryptionSdk.Materials.{DecryptionMaterials, EncryptedDataKey, EncryptionMaterials}
+
+  @type discovery_filter :: %{
+          partition: String.t(),
+          accounts: [String.t(), ...]
+        }
+
+  @type t :: %__MODULE__{
+          kms_client: struct(),
+          region: String.t(),
+          discovery_filter: discovery_filter() | nil,
+          grant_tokens: [String.t()]
+        }
+
+  @enforce_keys [:kms_client, :region]
+  defstruct [:kms_client, :region, :discovery_filter, grant_tokens: []]
+
+  @provider_id "aws-kms"
+
+  @doc """
+  Creates a new AWS KMS MRK Discovery Keyring.
+
+  ## Parameters
+
+  - `kms_client` - KMS client struct implementing KmsClient behaviour
+  - `region` - AWS region string for this keyring (e.g., "us-west-2")
+  - `opts` - Optional keyword list:
+    - `:discovery_filter` - Map with `:partition` (string) and `:accounts` (list of strings)
+    - `:grant_tokens` - List of grant tokens for KMS API calls
+
+  ## Returns
+
+  - `{:ok, keyring}` on success
+  - `{:error, reason}` on validation failure
+  """
+  @spec new(struct(), String.t(), keyword()) :: {:ok, t()} | {:error, term()}
+  def new(kms_client, region, opts \\ []) do
+    with :ok <- validate_client(kms_client),
+         :ok <- validate_region(region),
+         :ok <- validate_discovery_filter(opts[:discovery_filter]) do
+      {:ok,
+       %__MODULE__{
+         kms_client: kms_client,
+         region: region,
+         discovery_filter: opts[:discovery_filter],
+         grant_tokens: Keyword.get(opts, :grant_tokens, [])
+       }}
+    end
+  end
+
+  defp validate_client(nil), do: {:error, :client_required}
+  defp validate_client(%{__struct__: _module}), do: :ok
+  defp validate_client(_invalid), do: {:error, :invalid_client_type}
+
+  defp validate_region(nil), do: {:error, :region_required}
+  defp validate_region(""), do: {:error, :region_empty}
+  defp validate_region(region) when is_binary(region), do: :ok
+  defp validate_region(_invalid), do: {:error, :invalid_region_type}
+
+  defp validate_discovery_filter(nil), do: :ok
+
+  defp validate_discovery_filter(%{partition: partition, accounts: accounts})
+       when is_binary(partition) and is_list(accounts) do
+    cond do
+      accounts == [] ->
+        {:error, :discovery_filter_accounts_empty}
+
+      not Enum.all?(accounts, &is_binary/1) ->
+        {:error, :invalid_account_ids}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_discovery_filter(_invalid), do: {:error, :invalid_discovery_filter}
+
+  @doc """
+  MRK Discovery keyrings cannot encrypt - this always fails.
+  """
+  @spec wrap_key(t(), EncryptionMaterials.t()) :: {:error, :discovery_keyring_cannot_encrypt}
+  def wrap_key(%__MODULE__{}, %EncryptionMaterials{}) do
+    {:error, :discovery_keyring_cannot_encrypt}
+  end
+
+  # Placeholder for Phase 2
+  @spec unwrap_key(t(), DecryptionMaterials.t(), [EncryptedDataKey.t()]) ::
+          {:ok, DecryptionMaterials.t()} | {:error, term()}
+  def unwrap_key(%__MODULE__{}, %DecryptionMaterials{}, _edks) do
+    {:error, :not_implemented}
+  end
+
+  # Behaviour callbacks
+  @impl AwsEncryptionSdk.Keyring.Behaviour
+  def on_encrypt(_materials) do
+    {:error, {:must_use_wrap_key, "Call AwsKmsMrkDiscovery.wrap_key(keyring, materials) instead"}}
+  end
+
+  @impl AwsEncryptionSdk.Keyring.Behaviour
+  def on_decrypt(_materials, _encrypted_data_keys) do
+    {:error,
+     {:must_use_unwrap_key, "Call AwsKmsMrkDiscovery.unwrap_key(keyring, materials, edks) instead"}}
+  end
+end
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Module compiles: `mix compile`
+- [x] Constructor tests pass for valid inputs
+- [x] Constructor rejects nil client, nil/empty region, invalid filter
+
+#### Manual Verification:
+- [ ] IEx: `{:ok, keyring} = AwsKmsMrkDiscovery.new(mock_client, "us-west-2")` works
+- [ ] IEx: `AwsKmsMrkDiscovery.wrap_key(keyring, materials)` returns `{:error, :discovery_keyring_cannot_encrypt}`
+
+**Implementation Note**: After completing this phase and all automated verification passes, pause here for manual confirmation.
+
+---
+
+## Phase 2: OnDecrypt - MRK Region Handling
+
+### Overview
+Implement the core `unwrap_key/3` function with MRK-aware region handling - the key differentiator from the base discovery keyring.
+
+### Spec Requirements Addressed
+- Early return if materials already have plaintext data key
+- Filter EDKs by provider ID = "aws-kms"
+- Filter EDKs by valid ARN with resource type "key"
+- **For MRK: Reconstruct ARN with configured region**
+- **For non-MRK: Filter out if region doesn't match**
+- Validate response KeyId matches request KeyId
+- Validate plaintext length
+
+### Changes Required:
+
+#### 1. Implement unwrap_key and MRK handling
+**File**: `lib/aws_encryption_sdk/keyring/aws_kms_mrk_discovery.ex`
+**Changes**: Replace placeholder `unwrap_key/3` with full implementation
+
+```elixir
+  @doc """
+  Unwraps a data key using AWS KMS MRK Discovery.
+
+  For MRK EDKs, reconstructs the ARN with the keyring's configured region
+  before calling KMS Decrypt, enabling cross-region decryption.
+
+  For non-MRK EDKs, filters out any where the region doesn't match.
+  """
+  @spec unwrap_key(t(), DecryptionMaterials.t(), [EncryptedDataKey.t()]) ::
+          {:ok, DecryptionMaterials.t()} | {:error, term()}
+  def unwrap_key(%__MODULE__{} = keyring, %DecryptionMaterials{} = materials, edks) do
+    if KeyringBehaviour.has_plaintext_data_key?(materials) do
+      {:error, :plaintext_data_key_already_set}
+    else
+      try_decrypt_edks(keyring, materials, edks, [])
+    end
+  end
+
+  defp try_decrypt_edks(_keyring, _materials, [], errors) do
+    {:error, {:unable_to_decrypt_any_data_key, Enum.reverse(errors)}}
+  end
+
+  defp try_decrypt_edks(keyring, materials, [edk | rest], errors) do
+    case try_decrypt_edk(keyring, materials, edk) do
+      {:ok, plaintext} ->
+        DecryptionMaterials.set_plaintext_data_key(materials, plaintext)
+
+      {:error, reason} ->
+        try_decrypt_edks(keyring, materials, rest, [reason | errors])
+    end
+  end
+
+  defp try_decrypt_edk(keyring, materials, edk) do
+    with :ok <- match_provider_id(edk),
+         {:ok, arn} <- parse_provider_info_arn(edk),
+         :ok <- validate_resource_type_is_key(arn),
+         :ok <- passes_discovery_filter(keyring.discovery_filter, arn),
+         {:ok, decrypt_key_id} <- determine_decrypt_key_id(arn, keyring.region),
+         {:ok, plaintext} <- call_kms_decrypt(keyring, materials, edk, decrypt_key_id),
+         :ok <- validate_decrypted_length(plaintext, materials.algorithm_suite.kdf_input_length) do
+      {:ok, plaintext}
+    end
+  end
+
+  defp match_provider_id(%{key_provider_id: @provider_id}), do: :ok
+  defp match_provider_id(%{key_provider_id: id}), do: {:error, {:provider_id_mismatch, id}}
+
+  defp parse_provider_info_arn(edk) do
+    case KmsKeyArn.parse(edk.key_provider_info) do
+      {:ok, arn} -> {:ok, arn}
+      {:error, reason} -> {:error, {:invalid_provider_info_arn, reason}}
+    end
+  end
+
+  defp validate_resource_type_is_key(%{resource_type: "key"}), do: :ok
+  defp validate_resource_type_is_key(%{resource_type: type}), do: {:error, {:invalid_resource_type, type}}
+
+  # Discovery filter matching (reused from base discovery)
+  defp passes_discovery_filter(nil, _arn), do: :ok
+
+  defp passes_discovery_filter(%{partition: filter_partition, accounts: filter_accounts}, arn) do
+    with :ok <- match_partition(filter_partition, arn.partition) do
+      match_account(filter_accounts, arn.account)
+    end
+  end
+
+  defp match_partition(filter_partition, arn_partition) when filter_partition == arn_partition, do: :ok
+  defp match_partition(filter_partition, arn_partition) do
+    {:error, {:partition_mismatch, expected: filter_partition, actual: arn_partition}}
+  end
+
+  defp match_account(filter_accounts, arn_account) do
+    if arn_account in filter_accounts do
+      :ok
+    else
+      {:error, {:account_not_in_filter, account: arn_account, allowed: filter_accounts}}
+    end
+  end
+
+  # KEY DIFFERENTIATOR: MRK-aware region handling
+  defp determine_decrypt_key_id(arn, region) do
+    if KmsKeyArn.mrk?(arn) do
+      # MRK: Reconstruct ARN with configured region
+      reconstructed = %{arn | region: region}
+      {:ok, KmsKeyArn.to_string(reconstructed)}
+    else
+      # Non-MRK: Must be in same region
+      if arn.region == region do
+        {:ok, KmsKeyArn.to_string(arn)}
+      else
+        {:error, {:non_mrk_region_mismatch, expected: region, actual: arn.region}}
+      end
+    end
+  end
+
+  defp call_kms_decrypt(keyring, materials, edk, decrypt_key_id) do
+    client_module = keyring.kms_client.__struct__
+
+    result =
+      client_module.decrypt(
+        keyring.kms_client,
+        decrypt_key_id,
+        edk.ciphertext,
+        materials.encryption_context,
+        keyring.grant_tokens
+      )
+
+    with {:ok, response} <- result,
+         :ok <- verify_response_key_id(decrypt_key_id, response.key_id) do
+      {:ok, response.plaintext}
+    end
+  end
+
+  # MRK Discovery uses exact comparison (we already reconstructed the ARN)
+  defp verify_response_key_id(expected, actual) when expected == actual, do: :ok
+  defp verify_response_key_id(expected, actual) do
+    {:error, {:response_key_id_mismatch, expected, actual}}
+  end
+
+  defp validate_decrypted_length(plaintext, expected) when byte_size(plaintext) == expected, do: :ok
+  defp validate_decrypted_length(plaintext, expected) do
+    {:error, {:invalid_decrypted_length, expected: expected, actual: byte_size(plaintext)}}
+  end
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Tests pass: `mix test test/aws_encryption_sdk/keyring/aws_kms_mrk_discovery_test.exs`
+- [x] MRK cross-region decryption works
+- [x] Non-MRK different-region EDKs are filtered out
+- [x] Non-MRK same-region EDKs work
+
+#### Manual Verification:
+- [ ] IEx test: Create keyring in us-west-2, decrypt EDK from us-east-1 MRK
+
+**Implementation Note**: After completing this phase, pause for manual confirmation.
+
+---
+
+## Phase 3: CMM and Multi-Keyring Integration
+
+### Overview
+Add dispatch clauses so `AwsKmsMrkDiscovery` works with Default CMM and Multi-keyring.
+
+### Changes Required:
+
+#### 1. Update CMM Dispatch
+**File**: `lib/aws_encryption_sdk/cmm/default.ex`
+**Changes**: Add alias and dispatch clauses
+
+Add to alias line (line 37):
+```elixir
+alias AwsEncryptionSdk.Keyring.{AwsKms, AwsKmsDiscovery, AwsKmsMrk, AwsKmsMrkDiscovery, Multi, RawAes, RawRsa}
+```
+
+Add to @type keyring union (after line 46):
+```elixir
+| AwsKmsMrkDiscovery.t()
+```
+
+Add dispatch clause (after line 102):
+```elixir
+def call_wrap_key(%AwsKmsMrkDiscovery{} = keyring, materials) do
+  AwsKmsMrkDiscovery.wrap_key(keyring, materials)
+end
+```
+
+Add dispatch clause (after line 133):
+```elixir
+def call_unwrap_key(%AwsKmsMrkDiscovery{} = keyring, materials, edks) do
+  AwsKmsMrkDiscovery.unwrap_key(keyring, materials, edks)
+end
+```
+
+#### 2. Update Multi-Keyring Dispatch
+**File**: `lib/aws_encryption_sdk/keyring/multi.ex`
+**Changes**: Add alias and dispatch clauses
+
+Add to alias line (line 55):
+```elixir
+alias AwsEncryptionSdk.Keyring.{AwsKms, AwsKmsDiscovery, AwsKmsMrk, AwsKmsMrkDiscovery, RawAes, RawRsa}
+```
+
+Add dispatch clause (after line 229):
+```elixir
+defp call_wrap_key(%AwsKmsMrkDiscovery{} = keyring, materials) do
+  AwsKmsMrkDiscovery.wrap_key(keyring, materials)
+end
+```
+
+Add dispatch clause (after line 309):
+```elixir
+defp call_unwrap_key(%AwsKmsMrkDiscovery{} = keyring, materials, edks) do
+  AwsKmsMrkDiscovery.unwrap_key(keyring, materials, edks)
+end
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Tests pass: `mix quality --quick`
+- [x] CMM integration tests pass
+- [x] Multi-keyring integration tests pass
+
+#### Manual Verification:
+- [ ] IEx: CMM can use MRK Discovery keyring for decrypt
+- [ ] IEx: Multi-keyring can include MRK Discovery keyring
+
+**Implementation Note**: After completing this phase, pause for manual confirmation.
+
+---
+
+## Phase 4: Comprehensive Unit Tests
+
+### Overview
+Create complete test file covering all scenarios.
+
+### Changes Required:
+
+#### 1. Create Test File
+**File**: `test/aws_encryption_sdk/keyring/aws_kms_mrk_discovery_test.exs`
+**Changes**: Create comprehensive tests
+
+```elixir
+defmodule AwsEncryptionSdk.Keyring.AwsKmsMrkDiscoveryTest do
+  use ExUnit.Case, async: true
+
+  alias AwsEncryptionSdk.AlgorithmSuite
+  alias AwsEncryptionSdk.Cmm.Default, as: DefaultCmm
+  alias AwsEncryptionSdk.Keyring.{AwsKmsMrkDiscovery, Multi}
+  alias AwsEncryptionSdk.Keyring.KmsClient.Mock
+  alias AwsEncryptionSdk.Materials.{DecryptionMaterials, EncryptedDataKey, EncryptionMaterials}
+
+  @mrk_us_west "arn:aws:kms:us-west-2:123456789012:key/mrk-12345678123456781234567812345678"
+  @mrk_us_east "arn:aws:kms:us-east-1:123456789012:key/mrk-12345678123456781234567812345678"
+  @non_mrk_us_west "arn:aws:kms:us-west-2:123456789012:key/12345678-1234-1234-1234-123456789012"
+  @non_mrk_us_east "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+
+  describe "new/3" do
+    test "creates keyring with valid inputs" do
+      {:ok, mock} = Mock.new()
+      assert {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2")
+      assert keyring.kms_client == mock
+      assert keyring.region == "us-west-2"
+      assert keyring.discovery_filter == nil
+      assert keyring.grant_tokens == []
+    end
+
+    test "stores discovery filter and grant tokens" do
+      {:ok, mock} = Mock.new()
+      filter = %{partition: "aws", accounts: ["123456789012"]}
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2",
+        discovery_filter: filter,
+        grant_tokens: ["token1"]
+      )
+      assert keyring.discovery_filter == filter
+      assert keyring.grant_tokens == ["token1"]
+    end
+
+    test "rejects nil client" do
+      assert {:error, :client_required} = AwsKmsMrkDiscovery.new(nil, "us-west-2")
+    end
+
+    test "rejects nil region" do
+      {:ok, mock} = Mock.new()
+      assert {:error, :region_required} = AwsKmsMrkDiscovery.new(mock, nil)
+    end
+
+    test "rejects empty region" do
+      {:ok, mock} = Mock.new()
+      assert {:error, :region_empty} = AwsKmsMrkDiscovery.new(mock, "")
+    end
+
+    test "rejects invalid discovery filter" do
+      {:ok, mock} = Mock.new()
+      assert {:error, :invalid_discovery_filter} =
+        AwsKmsMrkDiscovery.new(mock, "us-west-2", discovery_filter: %{partition: "aws"})
+    end
+  end
+
+  describe "wrap_key/2" do
+    test "always fails - discovery keyrings cannot encrypt" do
+      {:ok, mock} = Mock.new()
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2")
+
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      materials = EncryptionMaterials.new_for_encrypt(suite, %{})
+
+      assert {:error, :discovery_keyring_cannot_encrypt} =
+        AwsKmsMrkDiscovery.wrap_key(keyring, materials)
+    end
+  end
+
+  describe "unwrap_key/3 - MRK same region" do
+    test "decrypts MRK EDK when regions match" do
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      plaintext_key = :crypto.strong_rand_bytes(32)
+      ciphertext = :crypto.strong_rand_bytes(128)
+
+      {:ok, mock} = Mock.new(%{
+        {:decrypt, @mrk_us_west} => %{
+          plaintext: plaintext_key,
+          key_id: @mrk_us_west
+        }
+      })
+
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2")
+      materials = DecryptionMaterials.new_for_decrypt(suite, %{})
+      edk = EncryptedDataKey.new("aws-kms", @mrk_us_west, ciphertext)
+
+      {:ok, result} = AwsKmsMrkDiscovery.unwrap_key(keyring, materials, [edk])
+      assert result.plaintext_data_key == plaintext_key
+    end
+  end
+
+  describe "unwrap_key/3 - MRK cross-region (KEY VALUE PROPOSITION)" do
+    test "decrypts us-east-1 MRK EDK with us-west-2 keyring" do
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      plaintext_key = :crypto.strong_rand_bytes(32)
+      ciphertext = :crypto.strong_rand_bytes(128)
+
+      # KMS in us-west-2 receives decrypt call with reconstructed ARN
+      reconstructed_arn = "arn:aws:kms:us-west-2:123456789012:key/mrk-12345678123456781234567812345678"
+
+      {:ok, mock} = Mock.new(%{
+        {:decrypt, reconstructed_arn} => %{
+          plaintext: plaintext_key,
+          key_id: reconstructed_arn
+        }
+      })
+
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2")
+      materials = DecryptionMaterials.new_for_decrypt(suite, %{})
+      # EDK from us-east-1 (different region!)
+      edk = EncryptedDataKey.new("aws-kms", @mrk_us_east, ciphertext)
+
+      {:ok, result} = AwsKmsMrkDiscovery.unwrap_key(keyring, materials, [edk])
+      assert result.plaintext_data_key == plaintext_key
+    end
+
+    test "decrypts us-west-2 MRK EDK with us-east-1 keyring" do
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      plaintext_key = :crypto.strong_rand_bytes(32)
+      ciphertext = :crypto.strong_rand_bytes(128)
+
+      reconstructed_arn = "arn:aws:kms:us-east-1:123456789012:key/mrk-12345678123456781234567812345678"
+
+      {:ok, mock} = Mock.new(%{
+        {:decrypt, reconstructed_arn} => %{
+          plaintext: plaintext_key,
+          key_id: reconstructed_arn
+        }
+      })
+
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-east-1")
+      materials = DecryptionMaterials.new_for_decrypt(suite, %{})
+      edk = EncryptedDataKey.new("aws-kms", @mrk_us_west, ciphertext)
+
+      {:ok, result} = AwsKmsMrkDiscovery.unwrap_key(keyring, materials, [edk])
+      assert result.plaintext_data_key == plaintext_key
+    end
+  end
+
+  describe "unwrap_key/3 - non-MRK region filtering" do
+    test "decrypts non-MRK EDK when region matches" do
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      plaintext_key = :crypto.strong_rand_bytes(32)
+      ciphertext = :crypto.strong_rand_bytes(128)
+
+      {:ok, mock} = Mock.new(%{
+        {:decrypt, @non_mrk_us_west} => %{
+          plaintext: plaintext_key,
+          key_id: @non_mrk_us_west
+        }
+      })
+
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2")
+      materials = DecryptionMaterials.new_for_decrypt(suite, %{})
+      edk = EncryptedDataKey.new("aws-kms", @non_mrk_us_west, ciphertext)
+
+      {:ok, result} = AwsKmsMrkDiscovery.unwrap_key(keyring, materials, [edk])
+      assert result.plaintext_data_key == plaintext_key
+    end
+
+    test "filters out non-MRK EDK from different region" do
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      ciphertext = :crypto.strong_rand_bytes(128)
+
+      {:ok, mock} = Mock.new()
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2")
+      materials = DecryptionMaterials.new_for_decrypt(suite, %{})
+      # EDK from us-east-1 non-MRK
+      edk = EncryptedDataKey.new("aws-kms", @non_mrk_us_east, ciphertext)
+
+      assert {:error, {:unable_to_decrypt_any_data_key, errors}} =
+        AwsKmsMrkDiscovery.unwrap_key(keyring, materials, [edk])
+
+      assert [{:non_mrk_region_mismatch, expected: "us-west-2", actual: "us-east-1"}] = errors
+    end
+  end
+
+  describe "unwrap_key/3 - discovery filter with MRK" do
+    test "applies filter before MRK reconstruction" do
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      ciphertext = :crypto.strong_rand_bytes(128)
+
+      {:ok, mock} = Mock.new()
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2",
+        discovery_filter: %{partition: "aws", accounts: ["999999999999"]}
+      )
+
+      materials = DecryptionMaterials.new_for_decrypt(suite, %{})
+      edk = EncryptedDataKey.new("aws-kms", @mrk_us_east, ciphertext)
+
+      assert {:error, {:unable_to_decrypt_any_data_key, errors}} =
+        AwsKmsMrkDiscovery.unwrap_key(keyring, materials, [edk])
+
+      assert [{:account_not_in_filter, account: "123456789012", allowed: ["999999999999"]}] = errors
+    end
+
+    test "MRK cross-region works with matching filter" do
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      plaintext_key = :crypto.strong_rand_bytes(32)
+      ciphertext = :crypto.strong_rand_bytes(128)
+
+      reconstructed_arn = "arn:aws:kms:us-west-2:123456789012:key/mrk-12345678123456781234567812345678"
+
+      {:ok, mock} = Mock.new(%{
+        {:decrypt, reconstructed_arn} => %{
+          plaintext: plaintext_key,
+          key_id: reconstructed_arn
+        }
+      })
+
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2",
+        discovery_filter: %{partition: "aws", accounts: ["123456789012"]}
+      )
+
+      materials = DecryptionMaterials.new_for_decrypt(suite, %{})
+      edk = EncryptedDataKey.new("aws-kms", @mrk_us_east, ciphertext)
+
+      {:ok, result} = AwsKmsMrkDiscovery.unwrap_key(keyring, materials, [edk])
+      assert result.plaintext_data_key == plaintext_key
+    end
+  end
+
+  describe "integration with Default CMM" do
+    test "CMM decrypt uses MRK discovery keyring" do
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      plaintext_key = :crypto.strong_rand_bytes(32)
+      ciphertext = :crypto.strong_rand_bytes(128)
+
+      {:ok, mock} = Mock.new(%{
+        {:decrypt, @mrk_us_west} => %{
+          plaintext: plaintext_key,
+          key_id: @mrk_us_west
+        }
+      })
+
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2")
+      cmm = DefaultCmm.new(keyring)
+
+      edk = EncryptedDataKey.new("aws-kms", @mrk_us_west, ciphertext)
+
+      request = %{
+        algorithm_suite: suite,
+        encryption_context: %{},
+        encrypted_data_keys: [edk],
+        commitment_policy: :require_encrypt_require_decrypt
+      }
+
+      {:ok, materials} = DefaultCmm.get_decryption_materials(cmm, request)
+      assert materials.plaintext_data_key == plaintext_key
+    end
+
+    test "CMM encrypt fails with MRK discovery keyring" do
+      {:ok, mock} = Mock.new()
+      {:ok, keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2")
+      cmm = DefaultCmm.new(keyring)
+
+      request = %{encryption_context: %{}, commitment_policy: :require_encrypt_require_decrypt}
+
+      assert {:error, :discovery_keyring_cannot_encrypt} =
+        DefaultCmm.get_encryption_materials(cmm, request)
+    end
+  end
+
+  describe "integration with Multi-keyring" do
+    test "multi-keyring can use MRK discovery keyring for decrypt" do
+      suite = AlgorithmSuite.aes_256_gcm_hkdf_sha512_commit_key()
+      plaintext_key = :crypto.strong_rand_bytes(32)
+      ciphertext = :crypto.strong_rand_bytes(128)
+
+      reconstructed_arn = "arn:aws:kms:us-west-2:123456789012:key/mrk-12345678123456781234567812345678"
+
+      {:ok, mock} = Mock.new(%{
+        {:decrypt, reconstructed_arn} => %{
+          plaintext: plaintext_key,
+          key_id: reconstructed_arn
+        }
+      })
+
+      {:ok, discovery_keyring} = AwsKmsMrkDiscovery.new(mock, "us-west-2")
+      {:ok, multi} = Multi.new(children: [discovery_keyring])
+
+      materials = DecryptionMaterials.new_for_decrypt(suite, %{})
+      edk = EncryptedDataKey.new("aws-kms", @mrk_us_east, ciphertext)
+
+      {:ok, result} = Multi.unwrap_key(multi, materials, [edk])
+      assert result.plaintext_data_key == plaintext_key
+    end
+  end
+end
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] All tests pass: `mix quality`
+- [x] No compiler warnings
+
+#### Manual Verification:
+- [ ] Review test coverage visually
+
+---
+
+## Final Verification
+
+After all phases complete:
+
+### Automated:
+- [x] Full test suite: `mix quality`
+- [x] Specific tests: `mix test test/aws_encryption_sdk/keyring/aws_kms_mrk_discovery_test.exs`
+
+### Manual:
+- [ ] IEx: Create MRK Discovery keyring with us-west-2 region
+- [ ] IEx: Verify cross-region decryption works (EDK from us-east-1, decrypt with us-west-2 keyring)
+- [ ] IEx: Verify non-MRK different-region EDK is filtered out
+
+## Testing Strategy
+
+### Unit Tests:
+- Constructor validation (client, region, discovery filter)
+- Encryption prohibition
+- MRK same-region decryption
+- **MRK cross-region decryption (key value proposition)**
+- Non-MRK same-region decryption
+- Non-MRK different-region filtering
+- Discovery filter application
+- Error collection and reporting
+
+### Manual Testing Steps:
+1. Start IEx with `iex -S mix`
+2. Create mock KMS client
+3. Create MRK Discovery keyring
+4. Test cross-region MRK decryption
+5. Test non-MRK filtering
+
+## References
+
+- Issue: #51
+- Research: `thoughts/shared/research/2026-01-28-GH51-aws-kms-mrk-discovery-keyring.md`
+- Spec - MRK Discovery Keyring: https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/framework/aws-kms/aws-kms-mrk-discovery-keyring.md
+- Spec - Discovery Keyring: https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/framework/aws-kms/aws-kms-discovery-keyring.md
+- Spec - MRK Match: https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/framework/aws-kms/aws-kms-mrk-match-for-decrypt.md

--- a/thoughts/shared/research/2026-01-28-GH51-aws-kms-mrk-discovery-keyring.md
+++ b/thoughts/shared/research/2026-01-28-GH51-aws-kms-mrk-discovery-keyring.md
@@ -1,0 +1,575 @@
+# Research: Implement AWS KMS MRK Discovery Keyring
+
+**Issue**: #51 - Implement AWS KMS MRK Discovery Keyring
+**Date**: 2026-01-28
+**Status**: Research complete
+
+## Issue Summary
+
+Implement the AWS KMS Multi-Region Key (MRK) Discovery Keyring - a decrypt-only keyring that combines discovery keyring behavior with MRK awareness. Unlike the basic discovery keyring that uses exact ARN matching, the MRK Discovery Keyring:
+
+1. **For MRK keys**: Reconstructs the ARN with the configured region before calling KMS Decrypt, enabling cross-region decryption
+2. **For non-MRK keys**: Filters out EDKs where the region doesn't match the keyring's configured region
+
+This enables applications to decrypt data encrypted with MRKs in any region using a single keyring configured for their local region.
+
+## Current Implementation State
+
+### Existing Code
+
+The KMS keyring infrastructure is complete and ready for extension:
+
+| File | Description | Status |
+|------|-------------|--------|
+| `lib/aws_encryption_sdk/keyring/aws_kms_discovery.ex` | Base discovery keyring pattern | Complete |
+| `lib/aws_encryption_sdk/keyring/aws_kms_mrk.ex` | MRK-aware keyring (GH50) | In progress |
+| `lib/aws_encryption_sdk/keyring/kms_key_arn.ex` | ARN parsing + MRK utilities | Complete |
+| `lib/aws_encryption_sdk/keyring/kms_client.ex` | KMS client behaviour | Complete |
+| `lib/aws_encryption_sdk/keyring/kms_client/ex_aws.ex` | ExAws implementation | Complete |
+| `lib/aws_encryption_sdk/keyring/kms_client/mock.ex` | Mock for testing | Complete |
+| `lib/aws_encryption_sdk/cmm/default.ex` | Default CMM with keyring dispatch | Complete |
+| `lib/aws_encryption_sdk/keyring/multi.ex` | Multi-keyring composition | Complete |
+
+### Key Discovery Keyring Pattern (from `aws_kms_discovery.ex`)
+
+The existing discovery keyring provides the base pattern:
+
+```elixir
+# Struct - MRK Discovery will add :region field
+defstruct [:kms_client, :discovery_filter, grant_tokens: []]
+
+# Key behavior: cannot encrypt
+def wrap_key(%__MODULE__{}, %EncryptionMaterials{}) do
+  {:error, :discovery_keyring_cannot_encrypt}
+end
+
+# Decryption flow:
+# 1. Check for existing plaintext key
+# 2. Filter EDKs by provider ID, ARN validity, discovery filter
+# 3. For each matching EDK, call KMS Decrypt using ARN from provider info
+# 4. Verify response KeyId matches expected (exact match at line 228)
+# 5. Validate decrypted length
+```
+
+**Critical Difference**: At line 228, the discovery keyring uses **exact comparison**:
+```elixir
+defp verify_response_key_id(expected, actual) when expected == actual, do: :ok
+```
+
+The MRK Discovery keyring must use **MRK matching** instead:
+```elixir
+defp verify_response_key_id(expected, actual) do
+  if KmsKeyArn.mrk_match?(expected, actual), do: :ok, else: {:error, ...}
+end
+```
+
+### Available MRK Utilities (from `kms_key_arn.ex`)
+
+```elixir
+# Parse ARN into struct
+@spec parse(String.t()) :: {:ok, t()} | {:error, term()}
+def parse(arn_string)
+
+# Check if identifier is MRK (mrk- prefix)
+@spec mrk?(t() | String.t()) :: boolean()
+def mrk?(identifier)
+
+# MRK match for decrypt - compares all components except region
+@spec mrk_match?(String.t(), String.t()) :: boolean()
+def mrk_match?(identifier_a, identifier_b)
+
+# Reconstruct ARN string from struct
+@spec to_string(t()) :: String.t()
+def to_string(%__MODULE__{} = arn)
+```
+
+### Relevant Patterns
+
+#### Struct Definition Pattern
+```elixir
+# From AwsKmsDiscovery
+@type discovery_filter :: %{
+  partition: String.t(),
+  accounts: [String.t(), ...]
+}
+
+@type t :: %__MODULE__{
+  kms_client: struct(),
+  discovery_filter: discovery_filter() | nil,
+  grant_tokens: [String.t()]
+}
+```
+
+#### Dispatch Pattern (for integration)
+```elixir
+# From cmm/default.ex and keyring/multi.ex
+def call_wrap_key(%AwsKmsDiscovery{} = keyring, materials) do
+  AwsKmsDiscovery.wrap_key(keyring, materials)
+end
+
+# Will need to add:
+def call_wrap_key(%AwsKmsMrkDiscovery{} = keyring, materials) do
+  AwsKmsMrkDiscovery.wrap_key(keyring, materials)
+end
+```
+
+### Dependencies
+
+**Required (Already Implemented):**
+- `AwsEncryptionSdk.Keyring.Behaviour` - Keyring interface
+- `AwsEncryptionSdk.Keyring.KmsClient` - KMS client abstraction
+- `AwsEncryptionSdk.Keyring.KmsKeyArn` - ARN parsing with MRK utilities
+
+**Depends On (Assumed Complete):**
+- `AwsEncryptionSdk.Keyring.AwsKmsDiscovery` (#49 - discovery keyring pattern)
+- `AwsEncryptionSdk.Keyring.AwsKmsMrk` (#50 - MRK matching patterns)
+
+**Blocks:**
+- Multi-Keyring Integration (dispatch clauses needed)
+- AWS KMS MRK Discovery Multi-Keyring (convenience constructor)
+
+## Specification Requirements
+
+### Source Documents
+
+- [aws-kms-mrk-discovery-keyring.md](https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/framework/aws-kms/aws-kms-mrk-discovery-keyring.md) - Primary specification
+- [aws-kms-discovery-keyring.md](https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/framework/aws-kms/aws-kms-discovery-keyring.md) - Base discovery behavior
+- [aws-kms-mrk-match-for-decrypt.md](https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/framework/aws-kms/aws-kms-mrk-match-for-decrypt.md) - MRK matching algorithm
+- [aws-kms-key-arn.md](https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/framework/aws-kms/aws-kms-key-arn.md) - ARN validation and MRK identification
+- [keyring-interface.md](https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/framework/keyring-interface.md) - Keyring interface
+
+### MUST Requirements
+
+#### Constructor (Initialization)
+
+1. **Required Parameters** (aws-kms-mrk-discovery-keyring.md)
+   > The keyring MUST accept the following parameters:
+   > - A required AWS KMS client
+   > - A required string indicating the region of the KMS client
+   > - An optional discovery filter that is an AWS partition and a set of AWS accounts
+   > - An optional list of AWS KMS grant tokens
+
+   Implementation: `new(kms_client, region, opts \\ [])` with `:discovery_filter` and `:grant_tokens` options
+
+2. **Non-null Client** (aws-kms-mrk-discovery-keyring.md)
+   > The AWS KMS SDK client MUST NOT be null
+
+   Implementation: Validate client is non-nil struct
+
+3. **Non-null Region** (aws-kms-mrk-discovery-keyring.md)
+   > The region MUST NOT be null or empty
+
+   Implementation: Validate region is non-nil, non-empty string
+
+4. **Discovery Filter Validation** (aws-kms-mrk-discovery-keyring.md)
+   > If discovery filter is provided, both partition and accounts MUST be present
+
+   Implementation: Reuse validation from `AwsKmsDiscovery.validate_discovery_filter/1`
+
+#### OnEncrypt
+
+5. **Encryption Prohibited** (aws-kms-mrk-discovery-keyring.md)
+   > This function MUST fail
+
+   Implementation: Return `{:error, :discovery_keyring_cannot_encrypt}` (same as base discovery)
+
+#### OnDecrypt
+
+6. **Early Return** (aws-kms-mrk-discovery-keyring.md)
+   > If decryption materials already contain valid plaintext data key, return immediately without modification
+
+   Implementation: Check `has_plaintext_data_key?(materials)` first
+
+7. **Filter EDKs - Provider ID** (aws-kms-mrk-discovery-keyring.md)
+   > Provider ID MUST be exactly "aws-kms"
+
+   Implementation: Match `edk.key_provider_id == "aws-kms"`
+
+8. **Filter EDKs - Valid ARN** (aws-kms-mrk-discovery-keyring.md)
+   > Provider info MUST be a valid AWS KMS ARN with resource type "key"
+
+   Implementation: Use `KmsKeyArn.parse/1` and check `arn.resource_type == "key"`
+
+9. **Filter EDKs - Discovery Filter** (aws-kms-mrk-discovery-keyring.md)
+   > If discovery filter set: partition must match, account must be in allowed list
+
+   Implementation: Reuse `passes_discovery_filter/2` from base discovery
+
+10. **MRK Region Handling** (aws-kms-mrk-discovery-keyring.md - **KEY DIFFERENTIATOR**)
+    > For each matching EDK, determine the key to use for decryption:
+    > - If the EDK's provider info ARN is identified as a multi-Region key:
+    >   **Construct a new ARN with the same partition, service, account, resource type,
+    >   and resource, but with the configured region**
+    > - If the EDK's provider info ARN is NOT a multi-Region key:
+    >   **The ARN's region MUST match the configured region, otherwise skip this EDK**
+
+    Implementation:
+    ```elixir
+    defp determine_decrypt_key_id(arn, region) do
+      if KmsKeyArn.mrk?(arn) do
+        # Reconstruct ARN with configured region
+        reconstructed = %{arn | region: region}
+        {:ok, KmsKeyArn.to_string(reconstructed)}
+      else
+        # Non-MRK: must be in same region
+        if arn.region == region do
+          {:ok, KmsKeyArn.to_string(arn)}
+        else
+          {:error, {:region_mismatch, expected: region, actual: arn.region}}
+        end
+      end
+    end
+    ```
+
+11. **KMS Decrypt Call** (aws-kms-mrk-discovery-keyring.md)
+    > Call AWS KMS Decrypt with:
+    > - KeyId: The determined key ARN (reconstructed for MRK, original for same-region non-MRK)
+    > - CiphertextBlob: The EDK ciphertext
+    > - EncryptionContext: From decryption materials
+    > - GrantTokens: Configured grant tokens
+
+12. **Validate Response KeyId** (aws-kms-mrk-discovery-keyring.md)
+    > The response KeyId MUST equal the request KeyId
+
+    Implementation: Exact string comparison (since we use the determined ARN)
+
+13. **Validate Plaintext Length** (aws-kms-mrk-discovery-keyring.md)
+    > Plaintext length MUST match algorithm suite's key derivation input length
+
+14. **Error Collection** (aws-kms-mrk-discovery-keyring.md)
+    > Collect all errors and continue to next EDK on failure
+
+15. **Final Error** (aws-kms-mrk-discovery-keyring.md)
+    > If no key decrypts successfully, yield error including all collected errors
+
+### SHOULD Requirements
+
+1. **Region Validation** (aws-kms-mrk-discovery-keyring.md)
+   > The keyring SHOULD fail initialization if the provided region does not match the region of the KMS client
+
+   Implementation: If client has a `region` field/function, compare and warn/error
+
+### MAY Requirements
+
+None explicitly stated.
+
+## Key Differences from Base Discovery Keyring
+
+| Aspect | AwsKmsDiscovery | AwsKmsMrkDiscovery |
+|--------|-----------------|---------------------|
+| **Struct Fields** | `kms_client, discovery_filter, grant_tokens` | + **`region`** (required) |
+| **OnEncrypt** | Error | Error (same) |
+| **MRK in Same Region** | Uses ARN from EDK | Uses ARN from EDK (same) |
+| **MRK in Different Region** | Skips (exact match fails) | **Reconstructs ARN with configured region** |
+| **Non-MRK in Same Region** | Uses ARN from EDK | Uses ARN from EDK (same) |
+| **Non-MRK in Different Region** | Attempts (may work if access) | **Filtered out explicitly** |
+| **Response KeyId Validation** | Exact string match | Exact string match (uses reconstructed ARN) |
+
+## Test Vectors
+
+### Harness Setup
+
+```elixir
+# Check availability
+TestVectorSetup.vectors_available?()
+
+# Find and load manifest
+{:ok, manifest_path} = TestVectorSetup.find_manifest("**/manifest.json")
+{:ok, harness} = TestVectorHarness.load_manifest(manifest_path)
+
+# List available tests
+test_ids = TestVectorHarness.list_test_ids(harness)
+```
+
+### Applicable Test Vector Sets
+
+- **awses-decrypt**: Decrypt test vectors with `type: "aws-kms-mrk-aware-discovery"`
+- Location: `test/fixtures/test_vectors/vectors/awses-decrypt/`
+- Manifest version: 2
+- Total MRK Discovery test cases: ~117 vectors
+
+### Available MRK Keys (from keys.json)
+
+| Key ID | ARN | Region | Resource ID |
+|--------|-----|--------|-------------|
+| `us-west-2-mrk` | `arn:aws:kms:us-west-2:658956600833:key/mrk-80bd8ecdcd4342aebd84b7dc9da498a7` | us-west-2 | mrk-80bd8ecdcd4342aebd84b7dc9da498a7 |
+| `us-east-1-mrk` | `arn:aws:kms:us-east-1:658956600833:key/mrk-80bd8ecdcd4342aebd84b7dc9da498a7` | us-east-1 | mrk-80bd8ecdcd4342aebd84b7dc9da498a7 |
+
+Both share the same MRK resource ID but different regions - this is the core MRK concept.
+
+### Implementation Order
+
+#### Phase 1: ARN Validation (Error Cases)
+
+Test that malformed ARNs are properly rejected/filtered:
+
+| Test ID | Error Description | Priority |
+|---------|-------------------|----------|
+| `495bfc25-24a6-4b65-9e20-47c58c6f1a01` | Colon-delimited ARN (should use slashes) | High |
+| `3aef648d-e636-4328-90d1-2e8f107c719c` | Missing `arn` prefix | High |
+| `267ef05f-d28b-49e2-a897-c1f1a7f69ffc` | Invalid `arn-not` prefix | High |
+| `317955eb-185a-4c92-b4b4-3fa195535b4c` | Malformed ARN structure | High |
+
+These validate that `KmsKeyArn.parse/1` correctly rejects malformed provider info ARNs.
+
+#### Phase 2: MRK Same Region (Basic Success)
+
+| Scenario | Setup | Expected |
+|----------|-------|----------|
+| MRK decrypt same region | keyring.region = "us-west-2", EDK from us-west-2-mrk | Success, no ARN reconstruction needed |
+| Non-MRK same region | keyring.region = "us-west-2", EDK from us-west-2 regular key | Success, exact ARN used |
+
+#### Phase 3: MRK Cross-Region (Core Value Proposition)
+
+| Scenario | Setup | Expected |
+|----------|-------|----------|
+| West keyring → East ciphertext | keyring.region = "us-west-2", EDK from us-east-1-mrk | **Success** - ARN reconstructed to us-west-2 |
+| East keyring → West ciphertext | keyring.region = "us-east-1", EDK from us-west-2-mrk | **Success** - ARN reconstructed to us-east-1 |
+
+This is the critical test - decrypt data encrypted in one region using MRK Discovery configured for another region.
+
+#### Phase 4: Non-MRK Region Filtering
+
+| Scenario | Setup | Expected |
+|----------|-------|----------|
+| Non-MRK different region | keyring.region = "us-west-2", EDK from us-east-1 regular key | **Filtered out** - EDK skipped |
+
+#### Phase 5: Discovery Filter + MRK
+
+| Scenario | Setup | Expected |
+|----------|-------|----------|
+| MRK matches filter | Filter: partition=aws, accounts=[123], MRK in different region | Success |
+| MRK fails partition filter | Filter: partition=aws-cn, MRK in partition=aws | Filtered out |
+| MRK fails account filter | Filter: accounts=[999], MRK in account 123 | Filtered out |
+
+### Test Vector Setup
+
+If test vectors are not present:
+
+```elixir
+TestVectorSetup.ensure_test_vectors()
+```
+
+Or manually:
+```bash
+mkdir -p test/fixtures/test_vectors
+curl -L https://github.com/awslabs/aws-encryption-sdk-test-vectors/raw/master/vectors/awses-decrypt/python-2.3.0.zip -o /tmp/python-vectors.zip
+unzip /tmp/python-vectors.zip -d test/fixtures/test_vectors
+rm /tmp/python-vectors.zip
+```
+
+## Implementation Considerations
+
+### Struct Definition
+
+```elixir
+defmodule AwsEncryptionSdk.Keyring.AwsKmsMrkDiscovery do
+  @type discovery_filter :: %{
+    partition: String.t(),
+    accounts: [String.t(), ...]
+  }
+
+  @type t :: %__MODULE__{
+    kms_client: struct(),
+    region: String.t(),           # NEW - required
+    discovery_filter: discovery_filter() | nil,
+    grant_tokens: [String.t()]
+  }
+
+  @enforce_keys [:kms_client, :region]
+  defstruct [:kms_client, :region, :discovery_filter, grant_tokens: []]
+end
+```
+
+### Technical Approach
+
+**Recommended**: Copy `AwsKmsDiscovery` and modify for MRK awareness.
+
+The key changes from base discovery:
+
+1. **Add `region` field** to struct (required)
+2. **Add region validation** in constructor
+3. **Add `determine_decrypt_key_id/2`** that handles MRK ARN reconstruction
+4. **Modify EDK filtering** to call `determine_decrypt_key_id/2` before attempting decrypt
+5. **Keep response validation** as exact match (using reconstructed ARN)
+
+```elixir
+# Core MRK handling logic
+defp try_decrypt_edk(keyring, materials, edk) do
+  with :ok <- match_provider_id(edk),
+       {:ok, arn} <- parse_provider_info_arn(edk),
+       :ok <- validate_resource_type_is_key(arn),
+       :ok <- passes_discovery_filter(keyring.discovery_filter, arn),
+       # NEW: Determine key ID with MRK handling
+       {:ok, decrypt_key_id} <- determine_decrypt_key_id(arn, keyring.region),
+       {:ok, plaintext} <- call_kms_decrypt(keyring, materials, edk, decrypt_key_id),
+       :ok <- validate_decrypted_length(plaintext, materials.algorithm_suite.kdf_input_length) do
+    {:ok, plaintext}
+  end
+end
+
+defp determine_decrypt_key_id(arn, region) do
+  if KmsKeyArn.mrk?(arn) do
+    # MRK: Reconstruct with configured region
+    reconstructed = %{arn | region: region}
+    {:ok, KmsKeyArn.to_string(reconstructed)}
+  else
+    # Non-MRK: Must be in same region
+    if arn.region == region do
+      {:ok, KmsKeyArn.to_string(arn)}
+    else
+      {:error, {:region_mismatch, expected: region, actual: arn.region}}
+    end
+  end
+end
+```
+
+### Potential Challenges
+
+1. **ARN Reconstruction**: Need to ensure `%{arn | region: region}` works correctly with the struct
+2. **Region Validation**: Getting region from different KMS client implementations may vary
+3. **Test Mocking**: Need to mock KMS to return different KeyIds for cross-region scenarios
+4. **Discovery Filter + MRK**: Ensure filter is applied before MRK reconstruction
+
+### Open Questions
+
+1. **Should we validate region matches client region?**
+   - The spec says SHOULD validate
+   - ExAws client stores region in struct - can compare
+   - Mock client may not have region - skip validation?
+   - Recommendation: Validate if client has `.region` field, otherwise skip with warning
+
+2. **What error code for region mismatch?**
+   - For non-MRK in different region, should we use `{:region_mismatch, ...}` or just skip?
+   - Recommendation: Use descriptive error `{:non_mrk_region_mismatch, ...}` to distinguish from other errors
+
+## Files to Create
+
+- `lib/aws_encryption_sdk/keyring/aws_kms_mrk_discovery.ex` - MRK Discovery keyring implementation
+- `test/aws_encryption_sdk/keyring/aws_kms_mrk_discovery_test.exs` - Unit tests
+
+## Files to Modify
+
+- `lib/aws_encryption_sdk/cmm/default.ex` - Add dispatch clauses for `%AwsKmsMrkDiscovery{}`
+- `lib/aws_encryption_sdk/keyring/multi.ex` - Add dispatch clauses for `%AwsKmsMrkDiscovery{}`
+
+### CMM Dispatch Additions
+
+```elixir
+# lib/aws_encryption_sdk/cmm/default.ex
+
+# Add to @type keyring union at line 40-46
+| AwsKmsMrkDiscovery.t()
+
+# Add alias at line 37
+alias AwsEncryptionSdk.Keyring.{AwsKms, AwsKmsDiscovery, AwsKmsMrk, AwsKmsMrkDiscovery, Multi, RawAes, RawRsa}
+
+# Add dispatch clause after line 98
+def call_wrap_key(%AwsKmsMrkDiscovery{} = keyring, materials) do
+  AwsKmsMrkDiscovery.wrap_key(keyring, materials)
+end
+
+# Add dispatch clause after line 129
+def call_unwrap_key(%AwsKmsMrkDiscovery{} = keyring, materials, edks) do
+  AwsKmsMrkDiscovery.unwrap_key(keyring, materials, edks)
+end
+```
+
+### Multi-Keyring Dispatch Additions
+
+```elixir
+# lib/aws_encryption_sdk/keyring/multi.ex
+
+# Add alias at line 55
+alias AwsEncryptionSdk.Keyring.{AwsKms, AwsKmsDiscovery, AwsKmsMrk, AwsKmsMrkDiscovery, RawAes, RawRsa}
+
+# Add dispatch clause after line 229
+defp call_wrap_key(%AwsKmsMrkDiscovery{} = keyring, materials) do
+  AwsKmsMrkDiscovery.wrap_key(keyring, materials)
+end
+
+# Add dispatch clause after line 309
+defp call_unwrap_key(%AwsKmsMrkDiscovery{} = keyring, materials, edks) do
+  AwsKmsMrkDiscovery.unwrap_key(keyring, materials, edks)
+end
+```
+
+## Example Usage
+
+```elixir
+alias AwsEncryptionSdk.Keyring.AwsKmsMrkDiscovery
+alias AwsEncryptionSdk.Keyring.KmsClient.ExAws
+
+# Create KMS client in us-west-2
+{:ok, kms_client} = ExAws.new(region: "us-west-2")
+
+# Create MRK Discovery keyring for us-west-2
+{:ok, keyring} = AwsKmsMrkDiscovery.new(kms_client, "us-west-2")
+
+# With discovery filter (restrict to specific partition/accounts)
+{:ok, keyring} = AwsKmsMrkDiscovery.new(kms_client, "us-west-2",
+  discovery_filter: %{
+    partition: "aws",
+    accounts: ["123456789012", "987654321098"]
+  }
+)
+
+# With grant tokens
+{:ok, keyring} = AwsKmsMrkDiscovery.new(kms_client, "us-west-2",
+  grant_tokens: ["token1", "token2"]
+)
+
+# Cannot encrypt - discovery keyrings are decrypt-only
+{:error, :discovery_keyring_cannot_encrypt} = AwsKmsMrkDiscovery.wrap_key(keyring, enc_materials)
+
+# Can decrypt MRK-encrypted data from ANY region
+# EDK was encrypted with us-east-1 MRK replica
+{:ok, materials} = AwsKmsMrkDiscovery.unwrap_key(keyring, dec_materials, edks)
+# Success! ARN was reconstructed to us-west-2 for the Decrypt call
+```
+
+## ARN Reconstruction Examples
+
+```elixir
+# Scenario 1: MRK Discovery keyring in us-west-2
+keyring_region = "us-west-2"
+
+# EDK encrypted with MRK in us-east-1:
+edk_provider_info = "arn:aws:kms:us-east-1:123456789012:key/mrk-1234abcd"
+
+# Since it's an MRK, reconstruct with keyring's region:
+decrypt_key_id = "arn:aws:kms:us-west-2:123456789012:key/mrk-1234abcd"
+# => Decrypt call uses us-west-2 replica
+
+# Scenario 2: Non-MRK in different region
+edk_provider_info = "arn:aws:kms:us-east-1:123456789012:key/regular-key-id"
+
+# Not an MRK and region doesn't match => EDK FILTERED OUT
+# (Won't even attempt decrypt)
+
+# Scenario 3: Non-MRK in same region
+edk_provider_info = "arn:aws:kms:us-west-2:123456789012:key/regular-key-id"
+
+# Not an MRK but region matches => Use original ARN
+decrypt_key_id = "arn:aws:kms:us-west-2:123456789012:key/regular-key-id"
+# => Decrypt call uses original ARN
+```
+
+## Recommended Next Steps
+
+1. Create implementation plan: `/create_plan thoughts/shared/research/2026-01-28-GH51-aws-kms-mrk-discovery-keyring.md`
+2. Ensure GH50 (AWS KMS MRK Keyring) is complete first
+3. Implement MRK Discovery keyring based on AwsKmsDiscovery pattern
+4. Add region field and MRK ARN reconstruction logic
+5. Add dispatch clauses to CMM and Multi-keyring
+6. Add unit tests with mock KMS client
+7. Add test vector tests for MRK discovery scenarios
+
+## References
+
+- Issue: https://github.com/[owner]/[repo]/issues/51
+- Spec - MRK Discovery Keyring: https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/framework/aws-kms/aws-kms-mrk-discovery-keyring.md
+- Spec - Discovery Keyring: https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/framework/aws-kms/aws-kms-discovery-keyring.md
+- Spec - MRK Match: https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/framework/aws-kms/aws-kms-mrk-match-for-decrypt.md
+- Spec - KMS Key ARN: https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/framework/aws-kms/aws-kms-key-arn.md
+- Test Vectors: https://github.com/awslabs/aws-encryption-sdk-test-vectors


### PR DESCRIPTION
- Adds AwsKmsMrkDiscovery module for cross-region decryption
- Reconstructs MRK ARNs with configured region for decrypt
- Filters non-MRK keys where region doesn't match
- Supports optional discovery filter (partition/accounts)
- Integrates with Default CMM and Multi-keyring dispatch
- Includes 28 tests covering cross-region scenarios
- Fixes compilation warnings in aws_kms_test.exs
- Captures deprecation logs in algorithm_suite_test.exs

Closes #51